### PR TITLE
Player Self-Harm Fix

### DIFF
--- a/src/game/server/sdk/sdk_player.cpp
+++ b/src/game/server/sdk/sdk_player.cpp
@@ -610,7 +610,7 @@ int CSDKPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 	if ( gpGlobals->teamplay )
 		bCheckFriendlyFire = true;
 
-	if ( !(bFriendlyFire || ( bCheckFriendlyFire && pInflictor->GetTeamNumber() != GetTeamNumber() ) || pInflictor == this ||	info.GetAttacker() == this) )
+	if ( !(bFriendlyFire || ( bCheckFriendlyFire && pInflictor->GetTeamNumber() != GetTeamNumber() ) /*|| pInflictor == this ||	info.GetAttacker() == this*/) )
 	{
 		if ( bFriendlyFire && (info.GetDamageType() & DMG_BLAST) == 0 )
 		{


### PR DESCRIPTION
Made a quick fix on players not being able to harm themselves by commenting out part of an if statement in sdk_player.cpp.
