### PR TITLE
Fix being stuck when dive-rolling in a place that only has enough room to go prone

### DIFF
--- a/mp/src/game/shared/da/da_gamemovement.cpp
+++ b/mp/src/game/shared/da/da_gamemovement.cpp
@@ -749,11 +749,7 @@ void CDAGameMovement::RealPlayerMove (void)
 	{
 		if ( CheckInterval( STUCK ) )
 		{
-			if ( CheckStuck() )
-			{
-				// Can't move, we're stuck
-				return;  
-			}
+			CheckStuck();
 		}
 	}
 
@@ -1918,14 +1914,29 @@ void CDAGameMovement::Duck( void )
 			m_pDAPlayer->m_Shared.EndRoll();
 			SetRollEyeOffset( 0.0 );
 
-			if (!CanUnduck())
+			if ( !CanUnprone() )
+			{
+				m_pDAPlayer->m_Shared.SetProne(true, true);
+				SetProneEyeOffset(1.0);
+			}
+			else if ( !CanUnduck() )
+			{
 				FinishDuck();
+			}
 		}
 		// before we begin to stand up from the roll, let's make sure we don't want to go prone instead
 		else if ( m_pDAPlayer->GetCurrentTime() > m_pDAPlayer->m_Shared.GetRollTime() + ROLL_TIME )
 		{
+			// force transition to prone if there won't be room to stand/duck
+			if ( !CanUnprone() )
+			{
+				m_pDAPlayer->m_Shared.EndRoll();
+				SetRollEyeOffset( 0.0 );
+				m_pDAPlayer->m_Shared.SetProne(true, true);
+				SetProneEyeOffset(1.0);
+			}
 			// force transition to duck if there won't be room to stand
-			if ( !CanUnduck() )
+			else if ( !CanUnduck() )
 			{
 				SetRollEyeOffset( 0.0 );
 				m_pDAPlayer->m_Shared.EndRoll();


### PR DESCRIPTION
This patch fixes a few instances of being stuck after a dive-roll by setting the player to prone when that situation is encountered.

I'm not quite sure if that's the correct way to switch from roll to prone. It appears to work, though.

I'm also not entirely sure if removing that "return" in ``CDAGameMovement::RealPlayerMove`` has any side effects, but I noticed none.
Removing it was a requirement for ``CDAGameMovement::Duck``, and thus the mitigation code, to run in all instances of stuckness (that I've been able to reproduce).

<sub>Same changes as #30 but retargeted to the ``develop`` branch.</sub>