### PR TITLE
Fix da_auto_unstick

### DIFF
--- a/mp/src/game/server/da/da_player.cpp
+++ b/mp/src/game/server/da/da_player.cpp
@@ -404,6 +404,8 @@ CDAPlayer::CDAPlayer()
 	m_flCurrentTime = gpGlobals->curtime;
 
 	m_iszCharacter = NULL_STRING;
+
+	m_flStuckTime = -1;
 }
 
 

--- a/mp/src/game/server/da/da_player.h
+++ b/mp/src/game/server/da/da_player.h
@@ -527,6 +527,7 @@ public:
 
 	int    m_iKills;
 	int    m_iDeaths;
+	float  m_flStuckTime;
 
 	CNetworkHandle(CDAPlayer, m_hKiller);
 	CNetworkHandle(CBaseEntity, m_hInflictor);

--- a/mp/src/game/shared/da/da_gamemovement.cpp
+++ b/mp/src/game/shared/da/da_gamemovement.cpp
@@ -134,8 +134,6 @@ public:
 
 	void AddBotTag(const char* tag);
 #endif
-
-	float m_flStuckTime;
 };
 
 #define ROLL_TIME 0.65f
@@ -160,7 +158,6 @@ CDAGameMovement::CDAGameMovement()
 #ifdef STUCK_DEBUG
 	m_flStuckCheck = 0;
 #endif
-	m_flStuckTime = -1;
 }
 
 CDAGameMovement::~CDAGameMovement()
@@ -611,19 +608,19 @@ void CDAGameMovement::PlayerMove (void)
 #ifndef CLIENT_DLL
 	if (da_auto_unstick.GetBool() && m_pDAPlayer->IsAlive() && PlayerIsStuck() && m_pDAPlayer->GetMoveType() != MOVETYPE_NOCLIP)
 	{
-		if (m_flStuckTime < 0)
-			m_flStuckTime = gpGlobals->curtime;
-		else if (gpGlobals->curtime - m_flStuckTime > 3)
+		if (m_pDAPlayer->m_flStuckTime < 0)
+			m_pDAPlayer->m_flStuckTime = gpGlobals->curtime;
+		else if (gpGlobals->curtime - m_pDAPlayer->m_flStuckTime > 3)
 		{
 			// Im hopelessly stuck. Respawn me.
 			CBaseEntity* spawn = DAGameRules()->GetPlayerSpawnSpot(m_pDAPlayer);
 			mv->SetAbsOrigin(spawn->GetAbsOrigin());
 			mv->m_vecVelocity = Vector(0, 0, 0);
-			m_flStuckTime = -1;
+			m_pDAPlayer->m_flStuckTime = -1;
 		}
 	}
 	else
-		m_flStuckTime = -1;
+		m_pDAPlayer->m_flStuckTime = -1;
 #endif
 
 #ifdef STUCK_DEBUG

--- a/mp/src/game/shared/da/da_gamemovement.cpp
+++ b/mp/src/game/shared/da/da_gamemovement.cpp
@@ -127,6 +127,9 @@ protected:
 	bool ResolveStanding( void );
 	void TracePlayerBBoxWithStep( const Vector &vStart, const Vector &vEnd, unsigned int fMask, int collisionGroup, trace_t &trace );
 public:
+	// A reference to the player whose movement is currently being considered.
+	// If additional per-player data is needed, put it into CDAPlayer and refer to it via m_pDAPlayer.
+	// Do not put it directly into CDAGameMovement, because there isn't an instance of that per player.
 	CDAPlayer *m_pDAPlayer;
 
 #ifdef STUCK_DEBUG


### PR DESCRIPTION
The source contains a feature (da_auto_unstick) which actually works quite well in unsticking players, as long as there is only one player on the server.

As soon as another player (or a bot) is on the player, it breaks.
This happens because certain state is stored in what appears to be a global variable.

My fix moves that to the individual CDAPlayer instances.

<sub>Same changes as #29 but retargeted to the ``develop`` branch.</sub>