### PR TITLE
Fix the bug that prevents players from diving right after spawning the first time on da_official

### DIFF
--- a/mp/src/game/server/da/da_player.cpp
+++ b/mp/src/game/server/da/da_player.cpp
@@ -1112,6 +1112,9 @@ void CDAPlayer::Spawn()
 	m_hRagdoll = NULL;
 	
 	BaseClass::Spawn();
+
+	SetGroundEntity(NULL);
+
 #if defined ( SDK_USE_STAMINA ) || defined ( SDK_USE_SPRINTING )
 	m_Shared.SetStamina( 100 );
 #endif


### PR DESCRIPTION
This patch resets the "last known ground entity" field right after calling ``CBasePlayer::Spawn``

This fixes the bug that prevents players from diving right after spawning the first time on da_official.
The bug also occurs after you switch from spectator to normal mode.

Explanation:
``CBasePlayer::Spawn`` invoked ``ClearFlags``, clearing, among others, ``FL_ONGROUND``.
However, it did not invoke ``SetGroundEntity(NULL);`` in order to remove the world entity from the "last ground entity" field.
This, in turn, made subsequent calls to ``SetGroundEntity`` do nothing, since that function returns early if the "last ground entity" field is the same as its parameter.
So despite ``FullWalkMove`` happily calling ``SetGroundEntity($worldentity)`` all the time, ``FL_ONGROUND`` wasn't set.

This patch works, but I'm not sure if this is the correct place to but the ``SetGroundEntity(NULL);`` call.

<sub>Same changes as #32 but retargeted to the ``develop`` branch.</sub>