### PR TITLE
Don't update style skill until after a respawn

### DIFF
--- a/mp/src/game/client/da/c_da_player.cpp
+++ b/mp/src/game/client/da/c_da_player.cpp
@@ -153,7 +153,8 @@ BEGIN_RECV_TABLE_NOBASE( CDAPlayerShared, DT_DAPlayerShared )
 	RecvPropBool( RECVINFO( m_bAimedIn ) ),
 	RecvPropFloat( RECVINFO( m_flAimIn ) ),
 	RecvPropFloat( RECVINFO( m_flSlowAimIn ) ),
-	RecvPropInt( RECVINFO( m_iStyleSkill ), 0, RecvProxy_Skill ),
+	RecvPropInt( RECVINFO( m_iStyleSkill ) ),
+	RecvPropInt( RECVINFO( m_iStyleSkillAfterRespawn ), 0, RecvProxy_Skill ),
 	RecvPropBool( RECVINFO( m_bSuperSkill ) ),
 	RecvPropDataTable( "dasharedlocaldata", 0, 0, &REFERENCE_RECV_TABLE(DT_DASharedLocalPlayerExclusive) ),
 

--- a/mp/src/game/client/da/vgui/folder_gui.cpp
+++ b/mp/src/game/client/da/vgui/folder_gui.cpp
@@ -799,7 +799,7 @@ bool CFolderMenu::IsLoadoutComplete()
 	if (!pPlayer->HasCharacterBeenChosen())
 		return false;
 
-	if (pPlayer->m_Shared.m_iStyleSkill == SKILL_NONE)
+	if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn == SKILL_NONE)
 		return false;
 
 	return true;

--- a/mp/src/game/server/da/da_player.cpp
+++ b/mp/src/game/server/da/da_player.cpp
@@ -146,6 +146,7 @@ BEGIN_SEND_TABLE_NOBASE( CDAPlayerShared, DT_DAPlayerShared )
 	SendPropFloat( SENDINFO( m_flAimIn ) ),
 	SendPropFloat( SENDINFO( m_flSlowAimIn ) ),
 	SendPropInt( SENDINFO( m_iStyleSkill ) ),
+	SendPropInt( SENDINFO( m_iStyleSkillAfterRespawn ) ),
 	SendPropBool( SENDINFO( m_bSuperSkill ) ),
 	
 	SendPropInt (SENDINFO (m_iWallFlipCount)),
@@ -1110,6 +1111,8 @@ void CDAPlayer::Spawn()
 	}
 
 	m_hRagdoll = NULL;
+
+	UpdateStyleSkill();
 	
 	BaseClass::Spawn();
 #if defined ( SDK_USE_STAMINA ) || defined ( SDK_USE_SPRINTING )
@@ -3260,28 +3263,17 @@ void CDAPlayer::SetStyleSkill(SkillID eSkill)
 	if (eSkill <= SKILL_NONE || eSkill >= SKILL_MAX)
 		eSkill = SKILL_MARKSMAN;
 
-	m_Shared.m_iStyleSkill = eSkill;
+	m_Shared.m_iStyleSkillAfterRespawn = eSkill;
+}
+
+void CDAPlayer::UpdateStyleSkill()
+{
+	m_Shared.m_iStyleSkill = m_Shared.m_iStyleSkillAfterRespawn;
+
 	SetStylePoints(0);
 	m_flStyleSkillCharge = 0;
 
 	m_bHasSuperSlowMo = false;
-
-	if (m_Shared.m_iStyleSkill != SKILL_TROLL)
-	{
-		ConVarRef da_max_grenades("da_max_grenades");
-		while (GetAmmoCount("grenades") > da_max_grenades.GetInt())
-		{
-			QAngle gunAngles;
-			VectorAngles( BodyDirection2D(), gunAngles );
-
-			Vector vecForward;
-			AngleVectors( gunAngles, &vecForward, NULL, NULL );
-
-			float flDiameter = sqrt( CollisionProp()->OBBSize().x * CollisionProp()->OBBSize().x + CollisionProp()->OBBSize().y * CollisionProp()->OBBSize().y );
-
-			SDKThrowWeapon(FindWeapon(DA_WEAPON_GRENADE), vecForward, gunAngles, flDiameter);
-		}
-	}
 }
 
 #if defined ( SDK_USE_PRONE )

--- a/mp/src/game/server/da/da_player.h
+++ b/mp/src/game/server/da/da_player.h
@@ -207,6 +207,7 @@ public:
 	void ShowSkillMenu();
 
 	void SetStyleSkill(SkillID eSkill);
+	void UpdateStyleSkill();
 
 	/*These 3 were made virtual for Double Action.
 	They enable us to have new shadow hulls.*/

--- a/mp/src/game/shared/da/da_player_shared.h
+++ b/mp/src/game/shared/da/da_player_shared.h
@@ -252,6 +252,7 @@ public:
 	float m_flAimInSpeed;
 
 	CNetworkVar( int, m_iStyleSkill );
+	CNetworkVar( int, m_iStyleSkillAfterRespawn );
 	CNetworkVar( bool, m_bSuperSkill );
 
 private:


### PR DESCRIPTION
This could be exploited by binding setskill commands to switch skills at will in order to, for instance, always start with 2 grenades or a second of slow motion.