### PR TITLE
(WIP) Allow keyboard-only weapon/skill selection

### DIFF
--- a/mp/src/game/client/sdk/vgui/da_buymenu.cpp
+++ b/mp/src/game/client/sdk/vgui/da_buymenu.cpp
@@ -190,7 +190,6 @@ void CDABuyMenu::OnKeyCodePressed( KeyCode code )
 {
 	if ( code == KEY_PAD_ENTER || code == KEY_ENTER )
 	{
-		engine->ServerCmd("buy random");
 
 		GetFolderMenu()->ShowPage( PANEL_BUY_EQUIP_CT );
 	}

--- a/mp/src/game/client/sdk/vgui/da_skillmenu.cpp
+++ b/mp/src/game/client/sdk/vgui/da_skillmenu.cpp
@@ -150,7 +150,7 @@ void CDASkillMenu::OnKeyCodePressed( KeyCode code )
 {
 	if ( code == KEY_PAD_ENTER || code == KEY_ENTER )
 	{
-		engine->ServerCmd("setskill random");
+		engine->ServerCmd("setskill random_if_unset");
 		engine->ServerCmd("respawn");
 		GetFolderMenu()->Close();
 	}

--- a/mp/src/game/client/sdk/vgui/folder_gui.cpp
+++ b/mp/src/game/client/sdk/vgui/folder_gui.cpp
@@ -206,7 +206,7 @@ void CFolderMenu::Update()
 			if (pszLocalized)
 				sLocalized += pszLocalized;
 
-			if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn)
+			if (pPlayer->m_Shared.HasStyleSkillAfterRespawn())
 			{
 				std::string sSkill = std::string("#DA_Skill_") + SkillIDToAlias((SkillID)pPlayer->m_Shared.m_iStyleSkillAfterRespawn.Get()) + "_Adjective";
 
@@ -562,7 +562,7 @@ void CFolderMenu::Update()
 
 		if (pSkillInfo && pSkillIcon)
 		{
-			if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn)
+			if (pPlayer->m_Shared.HasStyleSkillAfterRespawn())
 			{
 				pSkillInfo->SetText((std::string("#DA_SkillInfo_") + SkillIDToAlias((SkillID)pPlayer->m_Shared.m_iStyleSkillAfterRespawn.Get())).c_str());
 				pSkillIcon->SetImage(SkillIDToAlias((SkillID)pPlayer->m_Shared.m_iStyleSkillAfterRespawn.Get()));
@@ -745,7 +745,7 @@ bool CFolderMenu::ShouldShowCharacterOnly()
 	if (pPlayer->GetLoadoutWeight())
 		return false;
 
-	if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn != SKILL_NONE)
+	if (pPlayer->m_Shared.HasStyleSkillAfterRespawn())
 		return false;
 
 	if (m_pPage)
@@ -764,7 +764,7 @@ bool CFolderMenu::ShouldShowCharacterAndWeapons()
 	if (!pPlayer)
 		return true;
 
-	if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn != SKILL_NONE)
+	if (pPlayer->m_Shared.HasStyleSkillAfterRespawn())
 		return false;
 
 	if (m_pPage)
@@ -783,7 +783,7 @@ bool CFolderMenu::ShouldShowEverything()
 	if (!pPlayer)
 		return true;
 
-	if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn != SKILL_NONE || m_pPage && FStrEq(m_pPage->GetName(), PANEL_BUY_EQUIP_CT))
+	if (pPlayer->m_Shared.HasStyleSkillAfterRespawn() || m_pPage && FStrEq(m_pPage->GetName(), PANEL_BUY_EQUIP_CT))
 		return true;
 
 	return false;
@@ -799,7 +799,7 @@ bool CFolderMenu::IsLoadoutComplete()
 	if (!pPlayer->HasCharacterBeenChosen())
 		return false;
 
-	if (pPlayer->m_Shared.m_iStyleSkillAfterRespawn == SKILL_NONE)
+	if (!pPlayer->m_Shared.HasStyleSkillAfterRespawn())
 		return false;
 
 	return true;

--- a/mp/src/game/server/sdk/sdk_player.cpp
+++ b/mp/src/game/server/sdk/sdk_player.cpp
@@ -4652,6 +4652,15 @@ void CC_Skill(const CCommand& args)
 		return;
 	}
 
+	if (FStrEq(args[1], "random_if_unset"))
+	{
+		if (pPlayer->m_Shared.HasStyleSkillAfterRespawn())
+			return;
+
+		pPlayer->PickRandomSkill();
+
+		return;
+	}
 	pPlayer->SetStyleSkill(AliasToSkillID(args[1]));
 
 #ifdef WITH_DATA_COLLECTION

--- a/mp/src/game/shared/sdk/sdk_player_shared.cpp
+++ b/mp/src/game/shared/sdk/sdk_player_shared.cpp
@@ -625,6 +625,7 @@ CSDKPlayerShared::CSDKPlayerShared()
 	m_bRolling = false;
 	m_flSlideStartTime = 0;
 	m_flSlideAutoEndTime = 0;
+	m_iStyleSkill = m_iStyleSkillAfterRespawn = SKILL_NONE;
 }
 
 CSDKPlayerShared::~CSDKPlayerShared()

--- a/mp/src/game/shared/sdk/sdk_player_shared.h
+++ b/mp/src/game/shared/sdk/sdk_player_shared.h
@@ -163,6 +163,9 @@ public:
 
 	void ComputeWorldSpaceSurroundingBox( Vector *pVecWorldMins, Vector *pVecWorldMaxs );
 
+	bool HasStyleSkillAfterRespawn() const { return m_iStyleSkillAfterRespawn != SKILL_NONE; }
+
+
 private:
 
 #if defined ( SDK_USE_PRONE )


### PR DESCRIPTION
This change consists of two parts:

1. This PR, which makes enter not override the user-selected weapons and skill with a random choice.
2. Some changes in dab_\<language\>.txt (adding hotkeys for the weapons, skills and the clear and random buttons and buymenu.res (swapping plan D and grenade)

This PR might need some work in order to allow empty inventories without breaking things.

Here are screenshots of the menu changes I want to make:
![weapon selection] (http://images.akamai.steamusercontent.com/ugc/293105785736724589/E3EA5C17900A9BDA6EC416254E8CE60446A92456/)
![skill selection] (http://images.akamai.steamusercontent.com/ugc/293105785736725107/F971A260D8045288822DFE871EF815E41F36631B/)