### PR TITLE
Swap first-person viewmodel animations in order to match the gun blazes and third-person animations

### DIFF
--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -124,16 +124,16 @@ void CAkimboBase::PrimaryAttack (void)
 
 	if (shootright)
 	{
-		//if (rightclip != 1) act = ACT_VM_PRIMARYATTACK;
-		//else act = ACT_VM_DRYFIRE_LEFT;
-		act = ACT_VM_PRIMARYATTACK;
+		//if (rightclip != 1) act = ACT_VM_SECONDARYATTACK;
+		//else act = ACT_VM_DRYFIRE;
+		act = ACT_VM_SECONDARYATTACK;
 		rightclip--;
 	}
 	else
 	{
-		//if (leftclip != 1) act = ACT_VM_SECONDARYATTACK;
-		//else act = ACT_VM_DRYFIRE;
-		act = ACT_VM_SECONDARYATTACK;
+		//if (leftclip != 1) act = ACT_VM_PRIMARYATTACK;
+		//else act = ACT_VM_DRYFIRE_LEFT;
+		act = ACT_VM_PRIMARYATTACK;
 		leftclip--;
 	}
 


### PR DESCRIPTION
I just cleaned up the akimbo base class a bit.
I noticed this bug while doing a final test to see if some things I changed still work.