### PR TITLE
Fix akimbo quickreload

### DIFF
--- a/mp/src/game/client/da/hud/da_hud_ammo.cpp
+++ b/mp/src/game/client/da/hud/da_hud_ammo.cpp
@@ -228,7 +228,7 @@ void CHudAmmo::ShotFired(C_WeaponDABase* pWeapon, bool bAkimbo, bool bRight)
 	if (ConVarRef("da_vr_hud").GetBool() || UseVR())
 	{
 		if (bAkimbo)
-			CWeaponDABase::VRBulletFired(bRight?pWeapon->rightclip.Get():pWeapon->leftclip.Get(), bRight);
+			CWeaponDABase::VRBulletFired(bRight?pWeapon->m_iRightClip.Get():pWeapon->m_iLeftClip.Get(), bRight);
 		else
 			CWeaponDABase::VRBulletFired(m_iAmmo, true);
 	}

--- a/mp/src/game/server/da/da_player.cpp
+++ b/mp/src/game/server/da/da_player.cpp
@@ -2509,9 +2509,9 @@ void CDAPlayer::SDKThrowWeapon( CWeaponDABase *pWeapon, const Vector &vecForward
 			pThrow->VPhysicsDestroyObject(); 
 			pThrow->VPhysicsInitShadow(true, true);
 			if (i == 0)
-				pThrow->m_iClip1 = pAkimbos->rightclip;
+				pThrow->m_iClip1 = pAkimbos->m_iRightClip;
 			else
-				pThrow->m_iClip1 = pAkimbos->leftclip;
+				pThrow->m_iClip1 = pAkimbos->m_iLeftClip;
 
 			SDKThrowWeaponInternal(pThrow, vecForward, vecAngles, flDiameter);
 		}
@@ -2540,7 +2540,7 @@ void CDAPlayer::SDKThrowWeapon( CWeaponDABase *pWeapon, const Vector &vecForward
 
 			// Whatever's in our mag right now, consider that to be the left one and toss it.
 			pThrow->m_iClip1 = pWeapon->m_iClip1;
-			pWeapon->m_iClip1 = pAkimbo->rightclip;
+			pWeapon->m_iClip1 = pAkimbo->m_iRightClip;
 
 			SDKThrowWeaponInternal(pThrow, vecForward, vecAngles, flDiameter);
 

--- a/mp/src/game/shared/basecombatweapon_shared.h
+++ b/mp/src/game/shared/basecombatweapon_shared.h
@@ -633,10 +633,9 @@ protected:
 	int						m_iOldState;
 
 #endif // End Client .dll only
-public:
+protected:
 	/*Called in DefaultReload for sane akimbo implementation*/
-	typedef bool (*delegate_t) (CBaseCombatWeapon *self);
-	delegate_t reload_delegate;
+	virtual bool NeedsReload( int iClipSize1, int iClipSize2 );
 };
 
 #endif // COMBATWEAPON_SHARED_H

--- a/mp/src/game/shared/da/da_fx_shared.cpp
+++ b/mp/src/game/shared/da/da_fx_shared.cpp
@@ -194,7 +194,7 @@ void FX_FireBullets(
 			CAkimboBase* pAkimbo = dynamic_cast<CAkimboBase*>(pWeapon);
 			Assert(pAkimbo);
 			if (pAkimbo)
-				pPlayer->DoMuzzleFlash(pAkimbo->shootright?2:1);
+				pPlayer->DoMuzzleFlash(pAkimbo->m_bShootRight?2:1);
 		}
 	}
 	else

--- a/mp/src/game/shared/da/da_viewmodel.cpp
+++ b/mp/src/game/shared/da/da_viewmodel.cpp
@@ -107,7 +107,7 @@ void CDAViewModel::DoMuzzleFlash()
 		id = GetDAWeapon ()->GetWeaponID ();
 		if (DA_WEAPON_AKIMBO_BERETTA == id || DA_WEAPON_AKIMBO_M1911 == id)
 		{/*HACK: Alternate attachment for akimbos, where else to put this?*/
-			if (((CAkimboBase *)GetDAWeapon ())->shootright)
+			if (((CAkimboBase *)GetDAWeapon ())->m_bShootRight)
 				ParticleProp()->Create ("muzzleflash_pistol", PATTACH_POINT_FOLLOW, "2");
 			else
 				ParticleProp()->Create ("muzzleflash_pistol", PATTACH_POINT_FOLLOW, "1");
@@ -154,14 +154,14 @@ int CDAViewModel::DrawModel(int flags)
 		{
 			CWeaponDABase* pWeapon = dynamic_cast<CWeaponDABase*>(GetActiveWeapon());
 			if (pWeapon)
-				CWeaponDABase::DrawVRBullets(vecAmmo1, vecAmmo2, pWeapon->rightclip, pWeapon->GetMaxClip1()/2, true);
+				CWeaponDABase::DrawVRBullets(vecAmmo1, vecAmmo2, pWeapon->m_iRightClip, pWeapon->GetMaxClip1()/2, true);
 		}
 
 		if (GetAttachment(iAmmoL1, vecAmmo1) && GetAttachment(iAmmoL2, vecAmmo2))
 		{
 			CWeaponDABase* pWeapon = dynamic_cast<CWeaponDABase*>(GetActiveWeapon());
 			if (pWeapon)
-				CWeaponDABase::DrawVRBullets(vecAmmo1, vecAmmo2, pWeapon->leftclip, pWeapon->GetMaxClip1()/2, false);
+				CWeaponDABase::DrawVRBullets(vecAmmo1, vecAmmo2, pWeapon->m_iLeftClip, pWeapon->GetMaxClip1()/2, false);
 		}
 	}
 

--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -56,10 +56,10 @@ Activity CAkimboBase::ActivityOverride(Activity baseAct, bool *pRequired)
 	if (ACT_DA_PRIMARYATTACK <= act && act <= ACT_DA_PRIMARYATTACK_ROLL)
 	{
 		unsigned ndx = act - ACT_DA_PRIMARYATTACK;
-		if (!shootright)
-			act = (Activity)(ACT_DA_AKIMBO_LEFT + ndx);
-		else
+		if (shootright)
 			act = (Activity)(ACT_DA_AKIMBO_RIGHT + ndx);
+		else
+			act = (Activity)(ACT_DA_AKIMBO_LEFT + ndx);
 	}
 	return BaseClass::ActivityOverride(act, pRequired);
 }
@@ -134,25 +134,19 @@ void CAkimboBase::PrimaryAttack(void)
 
 	if (shootright)
 	{
-#if 0
-		if (rightclip != 1)
-			act = ACT_VM_SECONDARYATTACK;
-		else
-			act = ACT_VM_DRYFIRE;
-#else
 		act = ACT_VM_SECONDARYATTACK;
+#if 0
+		if (rightclip == 1)
+			act = ACT_VM_DRYFIRE;
 #endif
 		rightclip--;
 	}
 	else
 	{
-#if 0
-		if (leftclip != 1)
-			act = ACT_VM_PRIMARYATTACK;
-		else
-			act = ACT_VM_DRYFIRE_LEFT;
-#else
 		act = ACT_VM_PRIMARYATTACK;
+#if 0
+		if (leftclip == 1)
+			act = ACT_VM_DRYFIRE_LEFT;
 #endif
 		leftclip--;
 	}
@@ -162,7 +156,7 @@ void CAkimboBase::PrimaryAttack(void)
 	FinishAttack(pPlayer);
 
 	if (rightclip > 0 && leftclip > 0)
-		shootright = (bool)(shootright^1);
+		shootright = !shootright;
 	else if (rightclip > 0)
 		shootright = true;
 	else
@@ -178,7 +172,7 @@ void CAkimboBase::FinishReload(void)
 	{
 		return;
 	}
-	int take = min((clipsize << 1) - (rightclip + leftclip), total);
+	int take = min(clipsize * 2 - (rightclip + leftclip), total);
 	if (!owner->IsStyleSkillActive(SKILL_MARKSMAN))
 	{
 		owner->RemoveAmmo(take, m_iPrimaryAmmoType);
@@ -200,8 +194,7 @@ void CAkimboBase::FinishReload(void)
 
 void CAkimboBase::GiveDefaultAmmo(void)
 {
-	rightclip = GetMaxClip1() / 2;
-	leftclip = GetMaxClip1() / 2;
+	leftclip = rightclip = GetMaxClip1() / 2;
 	m_iClip1 = rightclip + leftclip;
 }
 

--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -87,11 +87,11 @@ bool CAkimboBase::Deploy()
 {
 	// Transfer iClip1 of single pistol to rightclip
 	CWeaponDABase *from = GetPlayerOwner()->m_hSwitchFrom;
-	DAWeaponID id1 = DA_WEAPON_NONE;
-	DAWeaponID id2 = AliasToWeaponID(GetSDKWpnData().m_szSingle);
+	DAWeaponID eFromId = DA_WEAPON_NONE;
+	DAWeaponID eSingleId = AliasToWeaponID(GetSDKWpnData().m_szSingle);
 	if (from)
-		id1 = from->GetWeaponID();
-	if (id1 == id2)
+		eFromId = from->GetWeaponID();
+	if (eFromId == eSingleId)
 	{
 		rightclip = from->m_iClip1;
 		m_iClip1 = leftclip + rightclip;
@@ -103,11 +103,11 @@ bool CAkimboBase::Holster(CBaseCombatWeapon *pSwitchingTo)
 {
 	// Transfer rightclip into iClip1 of single pistol
 	CWeaponDABase *to = (CWeaponDABase *)pSwitchingTo;
-	DAWeaponID id1 = DA_WEAPON_NONE;
-	DAWeaponID id2 = AliasToWeaponID(GetSDKWpnData().m_szSingle);
+	DAWeaponID eToId = DA_WEAPON_NONE;
+	DAWeaponID eSingleId = AliasToWeaponID(GetSDKWpnData().m_szSingle);
 	if (to)
-		id1 = to->GetWeaponID();
-	if (id1 == id2)
+		eToId = to->GetWeaponID();
+	if (eToId == eSingleId)
 	{
 		to->m_iClip1 = rightclip;
 	}

--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -26,16 +26,17 @@ END_NETWORK_TABLE()
 #endif
 LINK_ENTITY_TO_CLASS(weapon_akimbobase, CAkimboBase);
 
-static bool akimbo_reload(CAkimboBase *self)
+bool CAkimboBase::NeedsReload( int iClipSize1, int iClipSize2 )
 {
-	CBaseCombatCharacter *owner = self->GetOwner();
+	CBaseCombatCharacter *owner = GetOwner();
 	if (!owner)
 	{
 		return false;
 	}
-	int sum = self->m_iRightClip + self->m_iLeftClip;
-	int total = owner->GetAmmoCount(self->m_iPrimaryAmmoType);
-	int delta = min(self->GetMaxClip1() - sum, total);
+
+	int sum = m_iRightClip + m_iLeftClip;
+	int total = owner->GetAmmoCount(m_iPrimaryAmmoType);
+	int delta = min(GetMaxClip1() - sum, total);
 	if (delta != 0)
 	{
 		return true;
@@ -45,7 +46,6 @@ static bool akimbo_reload(CAkimboBase *self)
 
 CAkimboBase::CAkimboBase()
 {
-	reload_delegate = (delegate_t)akimbo_reload;
 	m_bShootRight = false;
 }
 

--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -1,7 +1,7 @@
 #include "cbase.h"
 #include "weapon_akimbobase.h"
 
-#if defined (CLIENT_DLL)
+#if defined(CLIENT_DLL)
 	#include "c_da_player.h"
 	#include "prediction.h"
 #else
@@ -26,42 +26,45 @@ END_NETWORK_TABLE()
 #endif
 LINK_ENTITY_TO_CLASS(weapon_akimbobase, CAkimboBase);
 
-static bool 
-akimbo_reload (CAkimboBase *self)
+static bool akimbo_reload(CAkimboBase *self)
 {
-	CBaseCombatCharacter *owner = self->GetOwner ();
+	CBaseCombatCharacter *owner = self->GetOwner();
 	if (!owner)
 	{
 		return false;
 	}
-	int sum = (self->rightclip + self->leftclip);
-	int total = owner->GetAmmoCount (self->m_iPrimaryAmmoType);
-	int delta = min (self->GetMaxClip1() - sum, total);
+	int sum = self->rightclip + self->leftclip;
+	int total = owner->GetAmmoCount(self->m_iPrimaryAmmoType);
+	int delta = min(self->GetMaxClip1() - sum, total);
 	if (delta != 0)
 	{
 		return true;
 	}
 	return false;
 }
-CAkimboBase::CAkimboBase ()
+
+CAkimboBase::CAkimboBase()
 {
 	reload_delegate = (delegate_t)akimbo_reload;
 	shootright = false;
 }
 
-Activity CAkimboBase::ActivityOverride (Activity baseAct, bool *pRequired)
-{/*Remap baseAct to the approrpiate left/right akimbo firing animation.*/
+Activity CAkimboBase::ActivityOverride(Activity baseAct, bool *pRequired)
+{
+	// Remap baseAct to the approrpiate left/right akimbo firing animation.
 	Activity act = baseAct;
 	if (ACT_DA_PRIMARYATTACK <= act && act <= ACT_DA_PRIMARYATTACK_ROLL)
 	{
 		unsigned ndx = act - ACT_DA_PRIMARYATTACK;
-		if (!shootright) act = (Activity)(ACT_DA_AKIMBO_LEFT + ndx);
-		else act = (Activity)(ACT_DA_AKIMBO_RIGHT + ndx);
+		if (!shootright)
+			act = (Activity)(ACT_DA_AKIMBO_LEFT + ndx);
+		else
+			act = (Activity)(ACT_DA_AKIMBO_RIGHT + ndx);
 	}
-	return BaseClass::ActivityOverride (act, pRequired);
+	return BaseClass::ActivityOverride(act, pRequired);
 }
 
-int CAkimboBase::GetTracerAttachment (void)
+int CAkimboBase::GetTracerAttachment(void)
 {
 	if (shootright)
 		return 2;
@@ -69,47 +72,54 @@ int CAkimboBase::GetTracerAttachment (void)
 	return 1;
 }
 
-Activity CAkimboBase::GetIdleActivity (void)
+Activity CAkimboBase::GetIdleActivity(void)
 {
-	//if (rightclip > 0 && leftclip > 0) return ACT_VM_IDLE;
-	//if (rightclip > 0 && leftclip == 0) return ACT_VM_IDLE_EMPTY_LEFT;
+#if 0
+	if (rightclip > 0 && leftclip > 0)
+		return ACT_VM_IDLE;
+	if (rightclip > 0 && leftclip == 0)
+		return ACT_VM_IDLE_EMPTY_LEFT;
+#endif
 	return ACT_VM_IDLE_EMPTY;
 }
 
-bool CAkimboBase::Deploy ()
+bool CAkimboBase::Deploy()
 {
-	/*Transfer iClip1 of single pistol to rightclip*/
-	CWeaponDABase *from = GetPlayerOwner ()->m_hSwitchFrom;
+	// Transfer iClip1 of single pistol to rightclip
+	CWeaponDABase *from = GetPlayerOwner()->m_hSwitchFrom;
 	DAWeaponID id1 = DA_WEAPON_NONE;
-	DAWeaponID id2 = AliasToWeaponID (GetSDKWpnData ().m_szSingle);
-	if (from) id1 = from->GetWeaponID ();
+	DAWeaponID id2 = AliasToWeaponID(GetSDKWpnData().m_szSingle);
+	if (from)
+		id1 = from->GetWeaponID();
 	if (id1 == id2)
 	{
 		rightclip = from->m_iClip1;
 		m_iClip1 = leftclip + rightclip;
 	}
-	return BaseClass::Deploy ();
+	return BaseClass::Deploy();
 }
 
-bool CAkimboBase::Holster (CBaseCombatWeapon *pSwitchingTo)
-{/*Transfer rightclip into iClip1 of single pistol*/
+bool CAkimboBase::Holster(CBaseCombatWeapon *pSwitchingTo)
+{
+	// Transfer rightclip into iClip1 of single pistol
 	CWeaponDABase *to = (CWeaponDABase *)pSwitchingTo;
 	DAWeaponID id1 = DA_WEAPON_NONE;
-	DAWeaponID id2 = AliasToWeaponID (GetSDKWpnData ().m_szSingle);
-	if (to) id1 = to->GetWeaponID ();
+	DAWeaponID id2 = AliasToWeaponID(GetSDKWpnData().m_szSingle);
+	if (to)
+		id1 = to->GetWeaponID();
 	if (id1 == id2)
 	{
 		to->m_iClip1 = rightclip;
 	}
-	return BaseClass::Holster (pSwitchingTo);
+	return BaseClass::Holster(pSwitchingTo);
 }
 
-void CAkimboBase::PrimaryAttack (void)
+void CAkimboBase::PrimaryAttack(void)
 {
 	Activity act;
 	if (rightclip <= 0 && leftclip <= 0) 
 	{
-		Reload ();
+		Reload();
 		return;
 	}
 	CDAPlayer *pPlayer = GetPlayerOwner();
@@ -124,49 +134,62 @@ void CAkimboBase::PrimaryAttack (void)
 
 	if (shootright)
 	{
-		//if (rightclip != 1) act = ACT_VM_SECONDARYATTACK;
-		//else act = ACT_VM_DRYFIRE;
+#if 0
+		if (rightclip != 1)
+			act = ACT_VM_SECONDARYATTACK;
+		else
+			act = ACT_VM_DRYFIRE;
+#else
 		act = ACT_VM_SECONDARYATTACK;
+#endif
 		rightclip--;
 	}
 	else
 	{
-		//if (leftclip != 1) act = ACT_VM_PRIMARYATTACK;
-		//else act = ACT_VM_DRYFIRE_LEFT;
+#if 0
+		if (leftclip != 1)
+			act = ACT_VM_PRIMARYATTACK;
+		else
+			act = ACT_VM_DRYFIRE_LEFT;
+#else
 		act = ACT_VM_PRIMARYATTACK;
+#endif
 		leftclip--;
 	}
 
-	SendWeaponAnim (act);
+	SendWeaponAnim(act);
 	m_iClip1 = leftclip + rightclip;
-	FinishAttack (pPlayer);
+	FinishAttack(pPlayer);
 
-	if (rightclip > 0 && leftclip > 0) shootright = (bool)(shootright^1);
-	else if (rightclip > 0) shootright = true;
-	else shootright = false;
+	if (rightclip > 0 && leftclip > 0)
+		shootright = (bool)(shootright^1);
+	else if (rightclip > 0)
+		shootright = true;
+	else
+		shootright = false;
 }
 
-void CAkimboBase::FinishReload (void)
+void CAkimboBase::FinishReload(void)
 {
 	CDAPlayer *owner = GetPlayerOwner();
-	int clipsize = GetMaxClip1()/2;
-	int total = owner->GetAmmoCount (m_iPrimaryAmmoType);
+	int clipsize = GetMaxClip1() / 2;
+	int total = owner->GetAmmoCount(m_iPrimaryAmmoType);
 	if (!owner)
 	{
 		return;
 	}
-	int take = min ((clipsize<<1) - (rightclip + leftclip), total);
-	if (!owner->IsStyleSkillActive (SKILL_MARKSMAN))
+	int take = min((clipsize << 1) - (rightclip + leftclip), total);
+	if (!owner->IsStyleSkillActive(SKILL_MARKSMAN))
 	{
-		owner->RemoveAmmo (take, m_iPrimaryAmmoType);
+		owner->RemoveAmmo(take, m_iPrimaryAmmoType);
 	}
-	int r = min (clipsize - rightclip, take);
+	int r = min(clipsize - rightclip, take);
 	if (r != 0)
 	{
 		rightclip += r;
 		take -= r;
 	}
-	int l = min (clipsize - leftclip, take);
+	int l = min(clipsize - leftclip, take);
 	if (l != 0)
 	{
 		leftclip += l;
@@ -175,46 +198,44 @@ void CAkimboBase::FinishReload (void)
 	m_iClip1 = rightclip + leftclip;
 }
 
-void CAkimboBase::GiveDefaultAmmo (void)
+void CAkimboBase::GiveDefaultAmmo(void)
 {
-	rightclip = GetMaxClip1 ()/2;
-	leftclip = GetMaxClip1 ()/2;
+	rightclip = GetMaxClip1() / 2;
+	leftclip = GetMaxClip1() / 2;
 	m_iClip1 = rightclip + leftclip;
 }
 
-void CAkimboBase::OnPickedUp (CBaseCombatCharacter *pNewOwner)
+void CAkimboBase::OnPickedUp(CBaseCombatCharacter *pNewOwner)
 {
 #ifdef GAME_DLL
-	CDAPlayer *pl;
-	CWeaponDABase *single;
-	char name[32];
-
-	pl = ToDAPlayer (pNewOwner);
-	Assert (pl != NULL);
+	CDAPlayer *pl = ToDAPlayer(pNewOwner);
+	Assert(pl != NULL);
 	if (!pl)
 	{
 		return;
 	}
-	/*Ensure player has a single with their akimbos*/
-	Q_snprintf (name, sizeof (name), "weapon_%s", GetSDKWpnData ().m_szSingle);
-	single = pl->FindWeapon (AliasToWeaponID (name));
+	// Ensure player has a single with their akimbos
+	char name[32];
+	Q_snprintf(name, sizeof(name), "weapon_%s", GetSDKWpnData().m_szSingle);
+	CWeaponDABase *single = pl->FindWeapon(AliasToWeaponID(name));
 	if (!single)
-	{/*Give them a single too*/
-		pl->GiveNamedItem (name);
+	{
+		// Give them a single too
+		pl->GiveNamedItem(name);
 	}
-	GiveDefaultAmmo ();
-	BaseClass::OnPickedUp (pNewOwner);
+	GiveDefaultAmmo();
+	BaseClass::OnPickedUp(pNewOwner);
 #endif
 }
 
-void CAkimboBase::CheckReload (void)
+void CAkimboBase::CheckReload(void)
 {
-	BaseClass::CheckReload ();
+	BaseClass::CheckReload();
 }
 
 int CAkimboBase::GetMaxClip1() const
 {
-	DAWeaponID eSingleID = AliasToWeaponID (GetSDKWpnData ().m_szSingle);
+	DAWeaponID eSingleID = AliasToWeaponID(GetSDKWpnData().m_szSingle);
 
 	CSDKWeaponInfo* pSingleInfo = CSDKWeaponInfo::GetWeaponInfo(eSingleID);
 
@@ -222,14 +243,14 @@ int CAkimboBase::GetMaxClip1() const
 	if (!pSingleInfo)
 		return BaseClass::GetMaxClip1();
 
-	return pSingleInfo->iMaxClip1*2;
+	return pSingleInfo->iMaxClip1 * 2;
 }
 
 // For weight purposes an akimbo weighs the same as a single.
 // This is so that the second entity in the player's inventory just adds another single's worth of weight.
 int CAkimboBase::GetWeight() const
 {
-	DAWeaponID eSingleID = AliasToWeaponID (GetSDKWpnData ().m_szSingle);
+	DAWeaponID eSingleID = AliasToWeaponID(GetSDKWpnData().m_szSingle);
 
 	CSDKWeaponInfo* pSingleInfo = CSDKWeaponInfo::GetWeaponInfo(eSingleID);
 
@@ -249,5 +270,5 @@ const Vector CAkimboBase::GetShootPosition(CDAPlayer* pShooter)
 	Vector vecPosition, vecRight;
 	pShooter->EyePositionAndVectors(&vecPosition, NULL, &vecRight, NULL);
 
-	return vecPosition + vecRight * (shootright?4:-4);
+	return vecPosition + vecRight * (shootright ? 4 : -4);
 }

--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -33,7 +33,7 @@ static bool akimbo_reload(CAkimboBase *self)
 	{
 		return false;
 	}
-	int sum = self->rightclip + self->leftclip;
+	int sum = self->m_iRightClip + self->m_iLeftClip;
 	int total = owner->GetAmmoCount(self->m_iPrimaryAmmoType);
 	int delta = min(self->GetMaxClip1() - sum, total);
 	if (delta != 0)
@@ -46,7 +46,7 @@ static bool akimbo_reload(CAkimboBase *self)
 CAkimboBase::CAkimboBase()
 {
 	reload_delegate = (delegate_t)akimbo_reload;
-	shootright = false;
+	m_bShootRight = false;
 }
 
 Activity CAkimboBase::ActivityOverride(Activity baseAct, bool *pRequired)
@@ -56,7 +56,7 @@ Activity CAkimboBase::ActivityOverride(Activity baseAct, bool *pRequired)
 	if (ACT_DA_PRIMARYATTACK <= act && act <= ACT_DA_PRIMARYATTACK_ROLL)
 	{
 		unsigned ndx = act - ACT_DA_PRIMARYATTACK;
-		if (shootright)
+		if (m_bShootRight)
 			act = (Activity)(ACT_DA_AKIMBO_RIGHT + ndx);
 		else
 			act = (Activity)(ACT_DA_AKIMBO_LEFT + ndx);
@@ -66,7 +66,7 @@ Activity CAkimboBase::ActivityOverride(Activity baseAct, bool *pRequired)
 
 int CAkimboBase::GetTracerAttachment(void)
 {
-	if (shootright)
+	if (m_bShootRight)
 		return 2;
 
 	return 1;
@@ -75,9 +75,9 @@ int CAkimboBase::GetTracerAttachment(void)
 Activity CAkimboBase::GetIdleActivity(void)
 {
 #if 0
-	if (rightclip > 0 && leftclip > 0)
+	if (m_iRightClip > 0 && m_iLeftClip > 0)
 		return ACT_VM_IDLE;
-	if (rightclip > 0 && leftclip == 0)
+	if (m_iRightClip > 0 && m_iLeftClip == 0)
 		return ACT_VM_IDLE_EMPTY_LEFT;
 #endif
 	return ACT_VM_IDLE_EMPTY;
@@ -85,7 +85,7 @@ Activity CAkimboBase::GetIdleActivity(void)
 
 bool CAkimboBase::Deploy()
 {
-	// Transfer iClip1 of single pistol to rightclip
+	// Transfer iClip1 of single pistol to m_iRightClip
 	CWeaponDABase *from = GetPlayerOwner()->m_hSwitchFrom;
 	DAWeaponID eFromId = DA_WEAPON_NONE;
 	DAWeaponID eSingleId = AliasToWeaponID(GetSDKWpnData().m_szSingle);
@@ -93,15 +93,15 @@ bool CAkimboBase::Deploy()
 		eFromId = from->GetWeaponID();
 	if (eFromId == eSingleId)
 	{
-		rightclip = from->m_iClip1;
-		m_iClip1 = leftclip + rightclip;
+		m_iRightClip = from->m_iClip1;
+		m_iClip1 = m_iLeftClip + m_iRightClip;
 	}
 	return BaseClass::Deploy();
 }
 
 bool CAkimboBase::Holster(CBaseCombatWeapon *pSwitchingTo)
 {
-	// Transfer rightclip into iClip1 of single pistol
+	// Transfer m_iRightClip into iClip1 of single pistol
 	CWeaponDABase *to = (CWeaponDABase *)pSwitchingTo;
 	DAWeaponID eToId = DA_WEAPON_NONE;
 	DAWeaponID eSingleId = AliasToWeaponID(GetSDKWpnData().m_szSingle);
@@ -109,7 +109,7 @@ bool CAkimboBase::Holster(CBaseCombatWeapon *pSwitchingTo)
 		eToId = to->GetWeaponID();
 	if (eToId == eSingleId)
 	{
-		to->m_iClip1 = rightclip;
+		to->m_iClip1 = m_iRightClip;
 	}
 	return BaseClass::Holster(pSwitchingTo);
 }
@@ -117,7 +117,7 @@ bool CAkimboBase::Holster(CBaseCombatWeapon *pSwitchingTo)
 void CAkimboBase::PrimaryAttack(void)
 {
 	Activity act;
-	if (rightclip <= 0 && leftclip <= 0) 
+	if (m_iRightClip <= 0 && m_iLeftClip <= 0) 
 	{
 		Reload();
 		return;
@@ -132,35 +132,35 @@ void CAkimboBase::PrimaryAttack(void)
 		return;
 	}
 
-	if (shootright)
+	if (m_bShootRight)
 	{
 		act = ACT_VM_SECONDARYATTACK;
 #if 0
-		if (rightclip == 1)
+		if (m_iRightClip == 1)
 			act = ACT_VM_DRYFIRE;
 #endif
-		rightclip--;
+		m_iRightClip--;
 	}
 	else
 	{
 		act = ACT_VM_PRIMARYATTACK;
 #if 0
-		if (leftclip == 1)
+		if (m_iLeftClip == 1)
 			act = ACT_VM_DRYFIRE_LEFT;
 #endif
-		leftclip--;
+		m_iLeftClip--;
 	}
 
 	SendWeaponAnim(act);
-	m_iClip1 = leftclip + rightclip;
+	m_iClip1 = m_iLeftClip + m_iRightClip;
 	FinishAttack(pPlayer);
 
-	if (rightclip > 0 && leftclip > 0)
-		shootright = !shootright;
-	else if (rightclip > 0)
-		shootright = true;
+	if (m_iRightClip > 0 && m_iLeftClip > 0)
+		m_bShootRight = !m_bShootRight;
+	else if (m_iRightClip > 0)
+		m_bShootRight = true;
 	else
-		shootright = false;
+		m_bShootRight = false;
 }
 
 void CAkimboBase::FinishReload(void)
@@ -172,30 +172,30 @@ void CAkimboBase::FinishReload(void)
 	{
 		return;
 	}
-	int take = min(clipsize * 2 - (rightclip + leftclip), total);
+	int take = min(clipsize * 2 - (m_iRightClip + m_iLeftClip), total);
 	if (!owner->IsStyleSkillActive(SKILL_MARKSMAN))
 	{
 		owner->RemoveAmmo(take, m_iPrimaryAmmoType);
 	}
-	int r = min(clipsize - rightclip, take);
+	int r = min(clipsize - m_iRightClip, take);
 	if (r != 0)
 	{
-		rightclip += r;
+		m_iRightClip += r;
 		take -= r;
 	}
-	int l = min(clipsize - leftclip, take);
+	int l = min(clipsize - m_iLeftClip, take);
 	if (l != 0)
 	{
-		leftclip += l;
+		m_iLeftClip += l;
 		take -= l;
 	}
-	m_iClip1 = rightclip + leftclip;
+	m_iClip1 = m_iRightClip + m_iLeftClip;
 }
 
 void CAkimboBase::GiveDefaultAmmo(void)
 {
-	leftclip = rightclip = GetMaxClip1() / 2;
-	m_iClip1 = rightclip + leftclip;
+	m_iLeftClip = m_iRightClip = GetMaxClip1() / 2;
+	m_iClip1 = m_iRightClip + m_iLeftClip;
 }
 
 void CAkimboBase::OnPickedUp(CBaseCombatCharacter *pNewOwner)
@@ -263,5 +263,5 @@ const Vector CAkimboBase::GetShootPosition(CDAPlayer* pShooter)
 	Vector vecPosition, vecRight;
 	pShooter->EyePositionAndVectors(&vecPosition, NULL, &vecRight, NULL);
 
-	return vecPosition + vecRight * (shootright ? 4 : -4);
+	return vecPosition + vecRight * (m_bShootRight ? 4 : -4);
 }

--- a/mp/src/game/shared/da/weapon_akimbobase.cpp
+++ b/mp/src/game/shared/da/weapon_akimbobase.cpp
@@ -86,31 +86,27 @@ Activity CAkimboBase::GetIdleActivity(void)
 bool CAkimboBase::Deploy()
 {
 	// Transfer iClip1 of single pistol to m_iRightClip
-	CWeaponDABase *from = GetPlayerOwner()->m_hSwitchFrom;
-	DAWeaponID eFromId = DA_WEAPON_NONE;
 	DAWeaponID eSingleId = AliasToWeaponID(GetSDKWpnData().m_szSingle);
-	if (from)
-		eFromId = from->GetWeaponID();
-	if (eFromId == eSingleId)
-	{
-		m_iRightClip = from->m_iClip1;
-		m_iClip1 = m_iLeftClip + m_iRightClip;
-	}
+
+	CWeaponDABase *pSingle = GetPlayerOwner()->FindWeapon(eSingleId);
+	Assert(pSingle);
+
+	m_iRightClip = pSingle->m_iClip1;
+	m_iClip1 = m_iLeftClip + m_iRightClip;
+
 	return BaseClass::Deploy();
 }
 
 bool CAkimboBase::Holster(CBaseCombatWeapon *pSwitchingTo)
 {
 	// Transfer m_iRightClip into iClip1 of single pistol
-	CWeaponDABase *to = (CWeaponDABase *)pSwitchingTo;
-	DAWeaponID eToId = DA_WEAPON_NONE;
 	DAWeaponID eSingleId = AliasToWeaponID(GetSDKWpnData().m_szSingle);
-	if (to)
-		eToId = to->GetWeaponID();
-	if (eToId == eSingleId)
-	{
-		to->m_iClip1 = m_iRightClip;
-	}
+
+	CWeaponDABase *pSingle = GetPlayerOwner()->FindWeapon(eSingleId);
+	Assert(pSingle);
+
+	pSingle->m_iClip1 = m_iRightClip;
+
 	return BaseClass::Holster(pSwitchingTo);
 }
 

--- a/mp/src/game/shared/da/weapon_akimbobase.h
+++ b/mp/src/game/shared/da/weapon_akimbobase.h
@@ -31,7 +31,8 @@ supplants this baseclass entirely.*/
 #include "ai_activity.h"
 
 enum
-{/*ActivityOverride expects these in this order*/
+{
+	// ActivityOverride expects these in this order
 	ACT_DA_AKIMBO_RIGHT = LAST_SHARED_ACTIVITY,
 	ACT_DA_AKIMBO_CROUCH_RIGHT,
 	ACT_DA_AKIMBO_PRONE_RIGHT,
@@ -44,7 +45,8 @@ enum
 	ACT_DA_AKIMBO_SLIDE_LEFT,
 	ACT_DA_AKIMBO_DIVE_LEFT,
 	ACT_DA_AKIMBO_ROLL_LEFT,
-	/*Anything after this is private*/
+
+	// Anything after this is private
 	LAST_SHARED_AKIMBO_ACTIVITY
 };
 
@@ -62,21 +64,21 @@ public:
 #ifdef GAME_DLL
 	DECLARE_DATADESC();
 #endif
-	CAkimboBase ();
+	CAkimboBase();
 	virtual bool IsPredicted() const { return true; }
-	virtual Activity ActivityOverride (Activity baseAct, bool *pRequired);
-	virtual int GetTracerAttachment (void);
-	virtual Activity GetIdleActivity (void);
-	virtual bool Deploy ();
-	virtual bool Holster (CBaseCombatWeapon *pSwitchingTo);
-	virtual void PrimaryAttack (void);
-	virtual void FinishReload (void);
-	virtual void GiveDefaultAmmo (void);
-	virtual void OnPickedUp (CBaseCombatCharacter *pNewOwner);
-	virtual	void CheckReload (void);
+	virtual Activity ActivityOverride(Activity baseAct, bool *pRequired);
+	virtual int GetTracerAttachment(void);
+	virtual Activity GetIdleActivity(void);
+	virtual bool Deploy();
+	virtual bool Holster(CBaseCombatWeapon *pSwitchingTo);
+	virtual void PrimaryAttack(void);
+	virtual void FinishReload(void);
+	virtual void GiveDefaultAmmo(void);
+	virtual void OnPickedUp(CBaseCombatCharacter *pNewOwner);
+	virtual	void CheckReload(void);
 
-	virtual int GetMaxClip1( void ) const;
-	virtual int GetWeight( void ) const;
+	virtual int GetMaxClip1(void) const;
+	virtual int GetWeight(void) const;
 
 	const Vector GetShootPosition(CDAPlayer* pShooter);
 public:

--- a/mp/src/game/shared/da/weapon_akimbobase.h
+++ b/mp/src/game/shared/da/weapon_akimbobase.h
@@ -81,6 +81,7 @@ public:
 	virtual int GetWeight(void) const;
 
 	const Vector GetShootPosition(CDAPlayer* pShooter);
-public:
+protected:
+	virtual bool NeedsReload( int iClipSize1, int iClipSize2 );
 };
 #endif

--- a/mp/src/game/shared/da/weapon_dabase.cpp
+++ b/mp/src/game/shared/da/weapon_dabase.cpp
@@ -59,9 +59,9 @@ BEGIN_NETWORK_TABLE( CWeaponDABase, DT_WeaponDABase )
 	RecvPropFloat( RECVINFO( m_flSpread ) ),
   	RecvPropBool( RECVINFO( m_bSwingSecondary ) ),
 
-	RecvPropInt(RECVINFO(leftclip)),
-	RecvPropInt(RECVINFO(rightclip)),
-	RecvPropBool(RECVINFO(shootright)),
+	RecvPropInt(RECVINFO(m_iLeftClip)),
+	RecvPropInt(RECVINFO(m_iRightClip)),
+	RecvPropBool(RECVINFO(m_bShootRight)),
 
 	RecvPropFloat( RECVINFO( m_flGrenadeThrowStart ) ),
 #else
@@ -79,9 +79,9 @@ BEGIN_NETWORK_TABLE( CWeaponDABase, DT_WeaponDABase )
 	SendPropFloat( SENDINFO( m_flNextBrawlTime ) ),
 	SendPropBool( SENDINFO( m_bSwingSecondary ) ),
 
-	SendPropInt(SENDINFO(leftclip)),
-	SendPropInt(SENDINFO(rightclip)),
-	SendPropBool(SENDINFO(shootright)),
+	SendPropInt(SENDINFO(m_iLeftClip)),
+	SendPropInt(SENDINFO(m_iRightClip)),
+	SendPropBool(SENDINFO(m_bShootRight)),
 
 	SendPropFloat( SENDINFO( m_flGrenadeThrowStart ) ),
 #endif
@@ -98,9 +98,9 @@ BEGIN_PREDICTION_DATA( CWeaponDABase )
 	DEFINE_PRED_FIELD( m_flNextBrawlTime, FIELD_FLOAT, FTYPEDESC_INSENDTABLE ),
 	DEFINE_PRED_FIELD( m_bSwingSecondary, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE ),
 
-	DEFINE_PRED_FIELD(leftclip, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),			
-	DEFINE_PRED_FIELD(rightclip, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
-	DEFINE_PRED_FIELD(shootright, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),	
+	DEFINE_PRED_FIELD(m_iLeftClip, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),			
+	DEFINE_PRED_FIELD(m_iRightClip, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_FIELD(m_bShootRight, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),	
 END_PREDICTION_DATA()
 #endif
 
@@ -112,9 +112,9 @@ LINK_ENTITY_TO_CLASS( weapon_da_base, CWeaponDABase );
 	BEGIN_DATADESC( CWeaponDABase )
 
 		// New weapon Think and Touch Functions go here..
-		DEFINE_FIELD(leftclip, FIELD_INTEGER),
-		DEFINE_FIELD(rightclip, FIELD_INTEGER),
-		DEFINE_FIELD(shootright, FIELD_BOOLEAN),
+		DEFINE_FIELD(m_iLeftClip, FIELD_INTEGER),
+		DEFINE_FIELD(m_iRightClip, FIELD_INTEGER),
+		DEFINE_FIELD(m_bShootRight, FIELD_BOOLEAN),
 	END_DATADESC()
 
 #endif
@@ -369,7 +369,7 @@ void CWeaponDABase::FinishAttack (CDAPlayer *pPlayer)
 			if (pHudAmmo)
 			{
 				if (dynamic_cast<CAkimboBase*>(this))
-					pHudAmmo->ShotFired(this, true, shootright);
+					pHudAmmo->ShotFired(this, true, m_bShootRight);
 				else
 					pHudAmmo->ShotFired(this, false, true);
 			}
@@ -1093,10 +1093,10 @@ int CWeaponDABase::DrawModel(int flags)
 			DrawVRBullets(vecAmmo1, vecAmmo2, m_iClip1, GetMaxClip1(), true);
 
 		if (GetAttachment("ammo_1_r", vecAmmo1) && GetAttachment("ammo_2_r", vecAmmo2))
-			DrawVRBullets(vecAmmo1, vecAmmo2, rightclip, GetMaxClip1()/2, true);
+			DrawVRBullets(vecAmmo1, vecAmmo2, m_iRightClip, GetMaxClip1()/2, true);
 
 		if (GetAttachment("ammo_1_l", vecAmmo1) && GetAttachment("ammo_2_l", vecAmmo2))
-			DrawVRBullets(vecAmmo1, vecAmmo2, leftclip, GetMaxClip1()/2, false);
+			DrawVRBullets(vecAmmo1, vecAmmo2, m_iLeftClip, GetMaxClip1()/2, false);
 	}
 	else
 		s_iMaxClip = GetMaxClip1();
@@ -1598,7 +1598,7 @@ void CWeaponDABase::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE
 				if (pAkimbo)
 				{
 					// Second pistol is always the left one
-					pAkimbo->leftclip = m_iClip1;
+					pAkimbo->m_iLeftClip = m_iClip1;
 					pAkimbo->SetOwner(pPlayer);
 
 					// Player already has a weapon like this one, so just remove this one.

--- a/mp/src/game/shared/da/weapon_dabase.h
+++ b/mp/src/game/shared/da/weapon_dabase.h
@@ -239,9 +239,9 @@ private:
 public:
 	/*TODO: These should be moved into the akimbo class, but for some reason
 	I can't get them to synch properly there.*/
-	CNetworkVar(int, leftclip);
-	CNetworkVar(int, rightclip);
-	CNetworkVar(bool, shootright);
+	CNetworkVar(int, m_iLeftClip);
+	CNetworkVar(int, m_iRightClip);
+	CNetworkVar(bool, m_bShootRight);
 };
 
 

--- a/mp/src/game/shared/da/weapon_dabase.h
+++ b/mp/src/game/shared/da/weapon_dabase.h
@@ -239,9 +239,9 @@ private:
 public:
 	/*TODO: These should be moved into the akimbo class, but for some reason
 	I can't get them to synch properly there.*/
-	CNetworkVar (int, leftclip);
-	CNetworkVar (int, rightclip);
-	CNetworkVar (bool, shootright);
+	CNetworkVar(int, leftclip);
+	CNetworkVar(int, rightclip);
+	CNetworkVar(bool, shootright);
 };
 
 


### PR DESCRIPTION
"slot1;wait;wait;slot3;wait;slot2" reloads a gun with an akimbo in the backpack much faster than normal.
This patch addresses that (last commit) and cleans up the akimbo code a bit (the other commits).

I recommend reviewing each commit separately in order to be able to better follow the changes.
You can tell GitHub to switch to ignore-whitespace mode by appending  "?w=1" to an address.