### PR TITLE
Fix sliding through certain glass panes

### DIFF
--- a/mp/src/game/server/da/da_player.cpp
+++ b/mp/src/game/server/da/da_player.cpp
@@ -786,7 +786,7 @@ void CDAPlayer::PreThink(void)
 		// we need to start from a higher offset if we're not diving (18 works!)
 		int iOffset = 13*!m_Shared.IsDiving();
 
-		UTIL_TraceHull(GetAbsOrigin() + Vector(0, 0, 5+iOffset), GetAbsOrigin() + vecNormalizedVelocity*40 + Vector(0, 0, 10), Vector(-16, -16, -16), Vector(16, 16, 16), MASK_SOLID_BRUSHONLY, this, COLLISION_GROUP_NONE, &tr );
+		UTIL_TraceHull(GetAbsOrigin() + Vector(0, 0, 5+iOffset), GetAbsOrigin() + vecNormalizedVelocity*40 + Vector(0, 0, 10), Vector(-16, -16, -15), Vector(16, 16, 14), MASK_SOLID_BRUSHONLY, this, COLLISION_GROUP_NONE, &tr );
 
 		CBaseEntity* pHit = NULL;
 


### PR DESCRIPTION
- da_trainingday: every single glass pane under those railings
- da_cocaine: both bathroom windows

If I further lift the lower bounds from -15 to -14, this hole on da_morgendorffer no longer opened by simply sliding over it:
![hole on da_morgendorffer](http://images.akamai.steamusercontent.com/ugc/280721044809110961/4960DF0135CC553C0E8B8639D9F44FDD28A778F6/)
Do we want that?