### PR TITLE
Remove particles involving view model when deploying a new weapon

### DIFF
--- a/mp/src/game/shared/sdk/weapon_sdkbase.cpp
+++ b/mp/src/game/shared/sdk/weapon_sdkbase.cpp
@@ -1965,6 +1965,11 @@ bool CWeaponSDKBase::Deploy( )
 
 		if (GetPlayerOwner()->GetCurrentTime() < GetPlayerOwner()->m_flDisarmRedraw)
 			return false;
+
+#ifdef CLIENT_DLL
+		CBaseViewModel* vm = GetPlayerOwner()->GetViewModel( m_nViewModelIndex );
+		vm->ParticleProp()->StopParticlesInvolving(vm);
+#endif
 	}
 
 	bool bDeploy = DefaultDeploy( (char*)GetViewModel(), (char*)GetWorldModel(), GetDeployActivity(), (char*)GetAnimPrefix() );


### PR DESCRIPTION
This fixes the "Cannot update control point 1 for effect 'muzzleflash_pistol/smg/rifle/shotgun'" message spam on the client.