### PR TITLE
Don't give superskilled players unlimited grenades

### DIFF
--- a/mp/src/game/shared/sdk/weapon_basesdkgrenade.cpp
+++ b/mp/src/game/shared/sdk/weapon_basesdkgrenade.cpp
@@ -198,8 +198,7 @@ void CBaseSDKGrenade::ItemPostFrame()
 //		else
 			ThrowGrenade();
 
-		if (!pPlayer->IsStyleSkillActive(SKILL_TROLL))
-			DecrementAmmo( pPlayer );
+		DecrementAmmo( pPlayer );
 
 		m_bPinPulled = false;
 		SendWeaponAnim( ACT_VM_THROW );	


### PR DESCRIPTION
This has been an inconsistency I thought I got rid of by making it impossible to switch to grenades.
However, there's still lastinv, which makes this relevant again.

@BSVino was this ever intentional? Is it still?