### PR TITLE
Add name labels to players in spectator mode

### DIFF
--- a/mp/game/dab/resource/clientscheme.res
+++ b/mp/game/dab/resource/clientscheme.res
@@ -416,6 +416,54 @@ Scheme
 		}
 		// fonts listed later in the order will only be used if they fulfill a range not already filled
 		// if a font fails to load then the subsequent fonts will replace
+		SpectatorNames
+		{
+			"1"
+			{
+				"name"		"Verdana"
+				"tall"		"9"
+				"weight"	"700"
+				"antialias" "1"
+				"yres"	"1 599"
+				"outline"	"1"
+			}
+			"2"
+			{
+				"name"		"Verdana"
+				"tall"		"12"
+				"weight"	"700"
+				"antialias" "1"
+				"yres"	"600 767"
+				"outline"	"1"
+			}
+			"3"
+			{
+				"name"		"Verdana"
+				"tall"		"14"
+				"weight"	"900"
+				"antialias" "1"
+				"yres"	"768 1023"
+				"outline"	"1"
+			}
+			"4"
+			{
+				"name"		"Verdana"
+				"tall"		"20"
+				"weight"	"900"
+				"antialias" "1"
+				"yres"	"1024 1199"
+				"outline"	"1"
+			}
+			"5"
+			{
+				"name"		"Verdana"
+				"tall"		"24"
+				"weight"	"900"
+				"antialias" "1"
+				"yres"	"1200 10000"
+				"outline"	"1"
+			}
+		}
 		Default
 		{
 			"1"


### PR DESCRIPTION
Should be useful when trying to spot excessive teaming.

![screenshot] (http://images.akamai.steamusercontent.com/ugc/272844811417771723/6D8EB1AF1F2C214074389BFB000ABEDD656A7602/)