### PR TITLE
Fix grenade double-throw

### DIFF
--- a/mp/src/game/shared/sdk/weapon_basesdkgrenade.cpp
+++ b/mp/src/game/shared/sdk/weapon_basesdkgrenade.cpp
@@ -193,19 +193,14 @@ void CBaseSDKGrenade::ItemPostFrame()
 	if ( m_bPinPulled && !(pPlayer->m_nButtons & IN_ATTACK) ) 
 	{
 		pPlayer->DoAnimationEvent( PLAYERANIMEVENT_ATTACK_PRIMARY );
-//		if (m_bSecondary)
-//			DropGrenade();
-//		else
-			ThrowGrenade();
+		ThrowGrenade();
 
 		DecrementAmmo( pPlayer );
 
-		m_bPinPulled = false;
 		SendWeaponAnim( ACT_VM_THROW );	
 		SetWeaponIdleTime( GetCurrentTime() + SequenceDuration() );
 
 		m_bPinPulled = false;
-//		m_bSecondary = false;
 	}
 	else if( m_bRedraw )
 	{

--- a/mp/src/game/shared/sdk/weapon_basesdkgrenade.cpp
+++ b/mp/src/game/shared/sdk/weapon_basesdkgrenade.cpp
@@ -193,12 +193,15 @@ void CBaseSDKGrenade::ItemPostFrame()
 	if ( m_bPinPulled && !(pPlayer->m_nButtons & IN_ATTACK) ) 
 	{
 		pPlayer->DoAnimationEvent( PLAYERANIMEVENT_ATTACK_PRIMARY );
-		ThrowGrenade();
+		if (CanDecrementAmmo(pPlayer))
+		{
+			ThrowGrenade();
 
-		DecrementAmmo( pPlayer );
+			DecrementAmmo(pPlayer);
 
-		SendWeaponAnim( ACT_VM_THROW );	
-		SetWeaponIdleTime( GetCurrentTime() + SequenceDuration() );
+			SendWeaponAnim(ACT_VM_THROW);
+			SetWeaponIdleTime(GetCurrentTime() + SequenceDuration());
+		}
 
 		m_bPinPulled = false;
 	}
@@ -256,6 +259,10 @@ void CBaseSDKGrenade::ItemPostFrame()
 
 #ifdef CLIENT_DLL
 
+	bool CBaseSDKGrenade::CanDecrementAmmo( CBaseCombatCharacter *pOwner )
+	{
+		return true;
+	}
 	void CBaseSDKGrenade::DecrementAmmo( CBaseCombatCharacter *pOwner )
 	{
 	}
@@ -292,6 +299,14 @@ void CBaseSDKGrenade::ItemPostFrame()
 	int CBaseSDKGrenade::CapabilitiesGet()
 	{
 		return bits_CAP_WEAPON_RANGE_ATTACK1; 
+	}
+
+	bool CBaseSDKGrenade::CanDecrementAmmo( CBaseCombatCharacter *pOwner )
+	{
+		if (!pOwner)
+			return false;
+
+		return pOwner->GetAmmoCount(m_iPrimaryAmmoType) >= 1;
 	}
 
 	//-----------------------------------------------------------------------------

--- a/mp/src/game/shared/sdk/weapon_basesdkgrenade.h
+++ b/mp/src/game/shared/sdk/weapon_basesdkgrenade.h
@@ -44,6 +44,7 @@ public:
 
 	virtual void	ItemPostFrame();
 	
+	bool			CanDecrementAmmo( CBaseCombatCharacter *pOwner );
 	void			DecrementAmmo( CBaseCombatCharacter *pOwner );
 	virtual void	StartGrenadeThrow();
 	virtual void	ThrowGrenade();


### PR DESCRIPTION
Previously, you were able to F-throw a grenade while already attack-throwing a grenade.

<sub>Reported by penguin god 935</sub>