### PR TITLE
Make primary 3rd person crosshair aim at everything a weapon can hit, except windows and grates

### DIFF
--- a/mp/src/game/client/sdk/hud/da_hud_crosshair.cpp
+++ b/mp/src/game/client/sdk/hud/da_hud_crosshair.cpp
@@ -178,7 +178,7 @@ void CDAHudCrosshair::Paint( void )
 
 		// Now trace to see where the player will hit
 		trace_t tr2;
-		UTIL_TraceLine( vecShootPosition, vecShootPosition + vecForward * 1000, MASK_SOLID|CONTENTS_DEBRIS|CONTENTS_HITBOX, pPlayer, COLLISION_GROUP_NONE, &tr2 );
+		UTIL_TraceLine( vecShootPosition, vecShootPosition + vecForward * 1000, MASK_SHOT|CONTENTS_GRATE, pPlayer, COLLISION_GROUP_NONE, &tr2 );
 
 		//DebugDrawLine(vecCamera, tr.endpos, 255, 0, 0, true, 0.1f);
 		//DebugDrawLine(vecShootPosition, tr2.endpos, 0, 0, 255, true, 0.1f);

--- a/mp/src/game/shared/sdk/sdk_player_shared.cpp
+++ b/mp/src/game/shared/sdk/sdk_player_shared.cpp
@@ -1751,7 +1751,7 @@ void CSDKPlayer::UpdateThirdCamera(const Vector& vecEye, const QAngle& angEye)
 
 	// Trace to see where the camera is pointing
 	trace_t tr;
-	UTIL_TraceLine( m_vecThirdCamera, m_vecThirdCamera + vecShoot * 99999, MASK_VISIBLE|CONTENTS_DEBRIS|CONTENTS_HITBOX, this, COLLISION_GROUP_NONE, &tr );
+	UTIL_TraceLine( m_vecThirdCamera, m_vecThirdCamera + vecShoot * 99999, MASK_SHOT & ~(CONTENTS_WINDOW), this, COLLISION_GROUP_NONE, &tr );
 
 	m_vecThirdTarget = tr.endpos;
 }


### PR DESCRIPTION
The secondary 3rd person crosshair now aims at everthing a weapon can hit, including windows and grates.

Fixes #76.
