### PR TITLE
Reset "already voted" flag on map change

### DIFF
--- a/mp/src/game/client/sdk/hud/da_hud_vote.cpp
+++ b/mp/src/game/client/sdk/hud/da_hud_vote.cpp
@@ -896,6 +896,7 @@ void CHudVote::LevelInit( void )
 	SetVoteActive( false );
 	m_flVoteResultCycleTime = -1;
 	m_flHideTime = -1;
+	m_bPlayerVoted = false;
 	m_flPostVotedHideTime = -1;
 }
 


### PR DESCRIPTION
This fixes a bug where that flag stays enabled if there's a map change while a vote that you have voted on is still visible.