### PR TITLE
DoubleAction gameinterface.cpp eventmanager hook (prevents ip's to be leaked and wont break anything)

### DIFF
--- a/mp/src/game/server/gameinterface.cpp
+++ b/mp/src/game/server/gameinterface.cpp
@@ -576,8 +576,7 @@ class C_VMT //vtable hooking class
 public:
 	C_VMT(void *Interface)
 	{
-		unsigned long dwInterface = (unsigned long)Interface;
-		ppInterface = (*(unsigned long***)&dwInterface);
+		ppInterface = (unsigned long**)Interface);// Windows UNSIGNED LONG cause it compiles in 32bit
 		pOldVMT = *ppInterface;
 		VMTSize = 0;
 		while (pOldVMT[VMTSize])VMTSize++;
@@ -608,7 +607,7 @@ class C_VMT //vtable hooking class
 public:
 	C_VMT(void *Interface)
 	{
-		ppInterface = (unsigned int**)Interface;
+		ppInterface = (unsigned int**)Interface;// unsigned int in Linux cause Unsigned long will be 64bit and the game actually is 32bit so you need unsigned int which is 32bit in Linux
 		pOldVMT = *ppInterface;
 		VMTSize = 0;
 		while (pOldVMT[VMTSize])VMTSize++;


### PR DESCRIPTION
gameinterface.cpp: added vtable hook for linux and windows hooking gameeventmanager->fireevent (to block ip leakage via gameevents) #116
Editing other files wont change this since it's hardcoded in engine.dll ( http://prntscr.com/j1a642 ) and engine.so ( http://prntscr.com/j1a4rj )

This method also doesn't break plugins that use player_connect for specific reasons (admin check for sourcemod for example, when someone connects).