### PR TITLE
Deactivate superfall when landing on solid ground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [v1.3.0.0](https://github.com/BSVino/DoubleAction/tree/v1.3.0.0) (2018-04-09)
+## [v1.3.0.0](https://github.com/BSVino/DoubleAction/tree/v1.3.0.0) (2018-04-08)
 [Full Changelog](https://github.com/BSVino/DoubleAction/compare/v1.2.2.2...v1.3.0.0)
 
 **Implemented enhancements:**

--- a/mp/src/game/client/sdk/c_sdk_player.h
+++ b/mp/src/game/client/sdk/c_sdk_player.h
@@ -196,6 +196,7 @@ public:
 	void ActivateSlowMo();
 	void ActivateSuperfallSlowMo();
 	void DeactivateSlowMo();
+	void DeactivateSuperfall();
 	float GetSlowMoMultiplier() const;
 	float GetSlowMoGoal() const;
 	float GetSlowMoSeconds() const { return m_flSlowMoSeconds; }

--- a/mp/src/game/server/sdk/sdk_player.h
+++ b/mp/src/game/server/sdk/sdk_player.h
@@ -324,6 +324,7 @@ public:
 	void ActivateSlowMo();
 	void ActivateSuperfallSlowMo();
 	void DeactivateSlowMo();
+	void DeactivateSuperfall();
 	float GetSlowMoMultiplier() const;
 	float GetSlowMoGoal() const;
 	int GetSlowMoType() const { return m_iSlowMoType; }

--- a/mp/src/game/shared/sdk/sdk_player_shared.cpp
+++ b/mp/src/game/shared/sdk/sdk_player_shared.cpp
@@ -1315,6 +1315,7 @@ void CSDKPlayerShared::PlayerOnGround( void )
 	m_flTimeLeftGround = m_pOuter->GetCurrentTime();
 	m_iWallFlipCount = 0;
 	m_flSuperFallOthersNextCheck = 0;
+	m_pOuter->DeactivateSuperfall();
 }
 
 void CSDKPlayerShared::ForceUnzoom( void )
@@ -1627,6 +1628,15 @@ void CSDKPlayer::DeactivateSlowMo()
 #ifdef GAME_DLL
 	SDKGameRules()->PlayerSlowMoUpdate(this);
 #endif
+}
+
+void CSDKPlayer::DeactivateSuperfall()
+{
+	m_Shared.m_bSuperFalling = false;
+
+	if (GetSlowMoType() == SLOWMO_SUPERFALL) {
+		DeactivateSlowMo();
+	}
 }
 
 float CSDKPlayer::GetSlowMoMultiplier() const

--- a/mp/src/game/shared/sdk/sdk_player_shared.cpp
+++ b/mp/src/game/shared/sdk/sdk_player_shared.cpp
@@ -1220,10 +1220,10 @@ bool CSDKPlayerShared::CanSuperFallRespawn()
 	if (!m_pOuter->IsAlive())
 		return false;
 
+#ifndef CLIENT_DLL
 	if (gpGlobals->curtime < m_flSuperFallOthersNextCheck)
 		return !m_bSuperFallOthersVisible;
 
-#ifndef CLIENT_DLL
 	m_bSuperFallOthersVisible = false;
 
 	for (int i = 1; i <= gpGlobals->maxClients; i++)


### PR DESCRIPTION
This prevents glitches when someone manages to climb back out of superfall.

Fixes #124