### PR TITLE
Prevent the player from closing the scoreboard while they're frozen

### DIFF
--- a/mp/src/game/client/in_main.cpp
+++ b/mp/src/game/client/in_main.cpp
@@ -537,7 +537,8 @@ void IN_ScoreDown( const CCommand &args )
 void IN_ScoreUp( const CCommand &args )
 {
 	KeyUp( &in_score, args[1] );
-	if ( gViewPortInterface )
+	CBasePlayer *player = CBasePlayer::GetLocalPlayer();
+	if ( gViewPortInterface && (!player || (player->GetFlags() & FL_FROZEN) == 0) )
 	{
 		gViewPortInterface->ShowPanel( PANEL_SCOREBOARD, false );
 		GetClientVoiceMgr()->StopSquelchMode();


### PR DESCRIPTION
This is kind of a hack to keep the scoreboard open during intermission.

Fixes #130