### PR TITLE
Fix infinite climb

### DIFF
--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -2549,6 +2549,15 @@ bool CSDKGameMovement::CheckMantel()
 	if (tr.m_pEnt && tr.m_pEnt->IsPlayer())
 		return false;
 
+	/*Then check whether we have enough vertical space to stand on the ledge*/
+	pr1 = pr2 = tr.endpos;
+	pr2.z += 4;
+	TraceBBox(pr1, pr2, VEC_HULL_MIN, VEC_HULL_MAX, tr);
+
+	if (tr.fraction < 1 || tr.allsolid || tr.startsolid)
+		/*Blocked by ceiling*/
+		return false;
+
 	pr1 = mv->GetAbsOrigin();
 	pr2 = pr1 + dir*4;
 	TraceBBox (pr1, pr2, vecMins, vecMaxs, tr);

--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -2557,7 +2557,7 @@ bool CSDKGameMovement::CheckMantel()
 	if (tr.plane.normal.z > 0.3)
 		return false;
 
-	if (tr.plane.normal.z < 0)
+	if (tr.plane.normal.z < -0.01)
 		return false;
 
 	m_pSDKPlayer->m_Shared.StartManteling(tr.plane.normal);


### PR DESCRIPTION
There are (depending on the way you count) between 2 and 5 spots for this on da_cocaine.
I also found that this change prevents you from grabbing on to the rails below the roof of the shed on da_megachat. Since this never allowed you to climb anywhere, I think that is acceptable.

Also I made one of the wall angle checks a little less prone to rounding errors, which would have prevented climbing up walls that are almost, but not quite perpendicular to the ground.
One such surface is the side of the big truck on da_cocaine that faces the small truck.

<sub>There are client/server dependencies on this one, but they should be minor enough to not matter.</sub>