### PR TITLE
Make spectate also reduce slowmo by the usual 2 seconds

### DIFF
--- a/mp/src/game/server/sdk/bots/sdk_bot.cpp
+++ b/mp/src/game/server/sdk/bots/sdk_bot.cpp
@@ -376,3 +376,20 @@ CON_COMMAND_F( bot_giveslowmo, "Give all bots one second of slow motion", FCVAR_
 			pPlayer->GiveSlowMo(1);
 	}
 }
+
+CON_COMMAND_F(giveslowmo, "Give all players one second of slow motion", FCVAR_CHEAT)
+{
+	for (int i = 1; i <= gpGlobals->maxClients; i++)
+	{
+		CSDKPlayer* pPlayer = ToSDKPlayer(UTIL_PlayerByIndex(i));
+
+		if (!pPlayer)
+			continue;
+
+		if (!pPlayer->IsAlive())
+			continue;
+
+		if (!pPlayer->IsBot())
+			pPlayer->GiveSlowMo(1);
+	}
+}

--- a/mp/src/game/server/sdk/sdk_player.cpp
+++ b/mp/src/game/server/sdk/sdk_player.cpp
@@ -1906,11 +1906,6 @@ void CSDKPlayer::Event_Killed( const CTakeDamageInfo &info )
 	if (m_flSlowMoTime)
 		DeactivateSlowMo();
 
-	m_flSlowMoSeconds -= 2;
-
-	if (m_flSlowMoSeconds < 0)
-		m_flSlowMoSeconds = 0;
-
 	m_flSlowMoTime = 0;
 	m_iSlowMoType = SLOWMO_NONE;
 
@@ -3754,6 +3749,11 @@ void CSDKPlayer::State_Enter_ACTIVE()
 void CSDKPlayer::State_Leave_ACTIVE()
 {
 	DropBriefcase();
+	m_flSlowMoSeconds -= 2;
+
+	if (m_flSlowMoSeconds < 0)
+		m_flSlowMoSeconds = 0;
+
 }
 
 void CSDKPlayer::State_PreThink_ACTIVE()

--- a/mp/src/game/server/sdk/sdk_player.cpp
+++ b/mp/src/game/server/sdk/sdk_player.cpp
@@ -1870,6 +1870,10 @@ void CSDKPlayer::Event_Killed( const CTakeDamageInfo &info )
 	// because we still want to transmit to the clients in our PVS.
 	CreateRagdollEntity();
 
+	// Turn off slow motion.
+	if (m_flSlowMoTime)
+		DeactivateSlowMo();
+
 	State_Transition( STATE_DEATH_ANIM );	// Transition into the dying state.
 
 	//Tony; after transition, remove remaining items
@@ -1901,10 +1905,6 @@ void CSDKPlayer::Event_Killed( const CTakeDamageInfo &info )
 		flLostPoints /= 2;
 
 	SetStylePoints(m_flStylePoints - flLostPoints);
-
-	// Turn off slow motion.
-	if (m_flSlowMoTime)
-		DeactivateSlowMo();
 
 	m_flSlowMoTime = 0;
 	m_iSlowMoType = SLOWMO_NONE;


### PR DESCRIPTION
Currently, you can just save your slowmo seconds by going to spectator mode, say, during a superfall.

Thanks to the Faceman for reporting!