### PR TITLE
Disable the overflow weapon drop mechanism by default

### DIFF
--- a/mp/src/game/client/hud_hintdisplay.cpp
+++ b/mp/src/game/client/hud_hintdisplay.cpp
@@ -105,7 +105,7 @@ void CHudHintDisplay::ApplySchemeSettings( vgui::IScheme *pScheme )
 	BaseClass::ApplySchemeSettings( pScheme );
 
 	SetFgColor( GetSchemeColor("HintMessageFg", pScheme) );
-	m_hFont = pScheme->GetFont( "HudHintText", true );
+	m_hFont = pScheme->GetFont( "HudHintTextLarge", true );
 	m_pLabel->SetBgColor( GetSchemeColor("HintMessageBg", pScheme) );
 	m_pLabel->SetPaintBackgroundType( 2 );
 	m_pLabel->SetSize( 0, GetTall() );		// Start tiny, it'll grow.

--- a/mp/src/game/client/sdk/hud/da_instructor.cpp
+++ b/mp/src/game/client/sdk/hud/da_instructor.cpp
@@ -882,7 +882,6 @@ void __MsgFunc_LessonLearned( bf_read &msg )
 }
 
 DECLARE_HUDELEMENT( CHudLessonPanel );
-DECLARE_HUD_MESSAGE( CHudLessonPanel, HintText );
 
 CHudLessonPanel::CHudLessonPanel( const char *pElementName ) : BaseClass(NULL, "HudLessonPanel"), CHudElement( pElementName )
 {
@@ -895,11 +894,7 @@ CHudLessonPanel::CHudLessonPanel( const char *pElementName ) : BaseClass(NULL, "
 
 void CHudLessonPanel::Init()
 {
-	HOOK_HUD_MESSAGE( CHudLessonPanel, HintText );
 	HOOK_MESSAGE( LessonLearned );
-
-	// listen for client side events
-	ListenForGameEvent( "player_hintmessage" );
 }
 
 inline std::string replace(std::string s, const std::string& f, const std::string& r)
@@ -1061,23 +1056,6 @@ void CHudLessonPanel::OnThink()
 		m_bLastLabelUpdateHack = (m_flLabelSizePercentage != 0.0 && m_flLabelSizePercentage != 1.0);
 		InvalidateLayout();
 	}
-}
-
-void CHudLessonPanel::MsgFunc_HintText( bf_read &msg )
-{
-	// Read the string(s)
-	char szString[255];
-	msg.ReadString( szString, sizeof(szString) );
-
-	char *tmpStr = hudtextmessage->LookupString( szString, NULL );
-	LocalizeAndDisplay( tmpStr, szString );
-}
-
-void CHudLessonPanel::FireGameEvent( IGameEvent * event)
-{
-	const char *hintmessage = event->GetString( "hintmessage" );
-	char *tmpStr = hudtextmessage->LookupString( hintmessage, NULL );
-	LocalizeAndDisplay( tmpStr, hintmessage );
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/client/sdk/hud/da_instructor.h
+++ b/mp/src/game/client/sdk/hud/da_instructor.h
@@ -71,8 +71,6 @@ public:
 
 	void Init();
 	void Reset();
-	void MsgFunc_HintText( bf_read &msg );
-	void FireGameEvent( IGameEvent * event);
 
 	bool SetHintText( wchar_t *text );
 	void LocalizeAndDisplay( const char *pszHudTxtMsg, const char *szRawString );

--- a/mp/src/game/client/sdk/hud/sdk_hud_notices.cpp
+++ b/mp/src/game/client/sdk/hud/sdk_hud_notices.cpp
@@ -298,13 +298,18 @@ void CHudNotices::ShowTopNotice()
 
 	pszObjectiveGoal = g_pVGuiLocalize->Find(VarArgs("#DA_MiniObjective_%s", NoticeToString(m_eTopNotice)));
 
-	if (m_eTopNotice == NOTICE_BOUNTY_ON_PLAYER || m_eTopNotice == NOTICE_BOUNTY_PROTECT_PLAYER || m_eTopNotice == NOTICE_BOUNTY_COLLECTED ||
-		m_eTopNotice == NOTICE_PLAYER_HAS_BRIEFCASE || m_eTopNotice == NOTICE_PLAYER_CAPTURED_BRIEFCASE ||
-		m_eTopNotice == NOTICE_RATRACE_PLAYER_LEAD || m_eTopNotice == NOTICE_RATRACE_OVER ||
-		m_eTopNotice == NOTICE_RATRACE_PLAYER_POINT_2)
-	{
-		g_pVGuiLocalize->ConstructString( sNoticeString, sizeof(sNoticeString), pszObjectiveGoal, 1, m_wszPlayerSubject );
-		pszObjectiveGoal = sNoticeString;
+	switch (m_eTopNotice) {
+		case NOTICE_BOUNTY_ON_PLAYER:
+		case NOTICE_BOUNTY_PROTECT_PLAYER:
+		case NOTICE_BOUNTY_COLLECTED:
+		case NOTICE_PLAYER_HAS_BRIEFCASE:
+		case NOTICE_PLAYER_CAPTURED_BRIEFCASE:
+		case NOTICE_RATRACE_PLAYER_LEAD:
+		case NOTICE_RATRACE_OVER:
+		case NOTICE_RATRACE_PLAYER_POINT_2:
+			g_pVGuiLocalize->ConstructString(sNoticeString, sizeof(sNoticeString), pszObjectiveGoal, 1, m_wszPlayerSubject);
+			pszObjectiveGoal = sNoticeString;
+			break;
 	}
 
 	if (!pszObjectiveGoal)

--- a/mp/src/game/shared/sdk/weapon_sdkbase.cpp
+++ b/mp/src/game/shared/sdk/weapon_sdkbase.cpp
@@ -1589,7 +1589,7 @@ void CWeaponSDKBase::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYP
 		pPlayer->DropWeaponsToPickUp(this);
 
 	if (iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT) {
-		CHintMessage("Inventory full", NULL, 6.0f).Send(pPlayer);
+		CHintMessage("Inventory full\nPress [%drop%] to drop weapon", NULL, 6.0f).Send(pPlayer);
 		return;
 	}
 

--- a/mp/src/game/shared/sdk/weapon_sdkbase.cpp
+++ b/mp/src/game/shared/sdk/weapon_sdkbase.cpp
@@ -12,6 +12,7 @@
 #include "ammodef.h"
 #include "weapon_akimbobase.h"
 #include "datacache/imdlcache.h"
+#include "hintmessage.h"
 
 #include "sdk_fx_shared.h"
 #include "sdk_gamerules.h"
@@ -1587,8 +1588,10 @@ void CWeaponSDKBase::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYP
 	if (da_drop_overflow_on_pickup.GetBool() && iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT)
 		pPlayer->DropWeaponsToPickUp(this);
 
-	if (iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT)
+	if (iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT) {
+		CHintMessage("Inventory full", NULL, 6.0f).Send(pPlayer);
 		return;
+	}
 
 	// ----------------------------------------
 	// If I already have it just take the ammo

--- a/mp/src/game/shared/sdk/weapon_sdkbase.cpp
+++ b/mp/src/game/shared/sdk/weapon_sdkbase.cpp
@@ -1559,6 +1559,8 @@ void CWeaponSDKBase::ItemPostFrame( void )
 	}
 }
 
+ConVar da_drop_overflow_on_pickup("da_drop_overflow_on_pickup", "0", FCVAR_ARCHIVE | FCVAR_USERINFO | FCVAR_CLIENTDLL, "Enable to drop weapons in order to make room for what you pick up.");
+
 extern bool UTIL_ItemCanBeTouchedByPlayer( CBaseEntity *pItem, CBasePlayer *pPlayer );
 
 void CWeaponSDKBase::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value )
@@ -1582,7 +1584,7 @@ void CWeaponSDKBase::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYP
 
 	int iWeight = GetWeight();
 
-	if (iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT)
+	if (da_drop_overflow_on_pickup.GetBool() && iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT)
 		pPlayer->DropWeaponsToPickUp(this);
 
 	if (iWeight + pPlayer->FindCurrentWeaponsWeight() > MAX_LOADOUT_WEIGHT)


### PR DESCRIPTION
Can be re-enabled by setting da_drop_overflow_on_pickup to 1.

I'm open to debate about the default value.
I'm also looking for a way to make a GUI option for this (and da_slide_unclick_time).

Fixes #93