### PR TITLE
Allow climbing through windows and other breakables

### DIFF
--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -115,8 +115,8 @@ public:
 
 	void    AccumulateWallFlipTime();
 
-	inline void TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm);
-	inline void TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm, unsigned int mask);
+	inline void TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm, ShouldHitFunc_t pExtraShouldHitCheckFn = NULL);
+	inline void TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm, unsigned int mask, ShouldHitFunc_t pExtraShouldHitCheckFn = NULL);
 	virtual void FullWalkMove ();
 	virtual void StepMove (Vector &vecDestination, trace_t &trace);
 
@@ -2490,16 +2490,16 @@ Vector CSDKGameMovement::GetPlayerViewOffset( bool ducked ) const
 	return BaseClass::GetPlayerViewOffset(ducked);
 }
 
-inline void CSDKGameMovement::TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm, unsigned int mask)
+inline void CSDKGameMovement::TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm, unsigned int mask, ShouldHitFunc_t pExtraShouldHitCheckFn)
 {
 	Ray_t ray;
 	ray.Init (start, end, mins, maxs);
-	UTIL_TraceRay(ray, mask, mv->m_nPlayerHandle.Get(), COLLISION_GROUP_PLAYER_MOVEMENT, &pm);
+	UTIL_TraceRay(ray, mask, mv->m_nPlayerHandle.Get(), COLLISION_GROUP_PLAYER_MOVEMENT, &pm, pExtraShouldHitCheckFn);
 }
 
-inline void CSDKGameMovement::TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm)
+inline void CSDKGameMovement::TraceBBox(const Vector& start, const Vector& end, const Vector &mins, const Vector &maxs, trace_t &pm, ShouldHitFunc_t pExtraShouldHitCheckFn)
 {
-	TraceBBox(start, end, mins, maxs, pm, PlayerSolidMask());
+	TraceBBox(start, end, mins, maxs, pm, PlayerSolidMask(), pExtraShouldHitCheckFn);
 }
 
 bool CSDKGameMovement::CheckMantel()


### PR DESCRIPTION
Usually, if there's a window with less than 4 units of standing space in front of it, you cannot climb into it without first breaking it.
This PR changes that.

Affected windows as far as I know:
- The cafeteria windows on da_holdingcell
- The windows near the ramp house area on da_rooftops