### PR TITLE
Fix another infinite climb bug

### DIFF
--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -2869,25 +2869,23 @@ void CSDKGameMovement::FullWalkMove ()
 		}
 
 		mv->SetAbsOrigin (tr.endpos);
-		if (m_pSDKPlayer->m_Shared.IsManteling())
+		if (!m_pSDKPlayer->m_Shared.IsManteling())
+			return;
+
+		// Try to push the player onto the ledge.
+		Vector vecOrigin = mv->GetAbsOrigin();
+		Vector vecTarget = vecOrigin + Vector(m_vecForward.x, m_vecForward.y, 0).Normalized();
+
+		TraceBBox(vecOrigin, vecTarget, mins, maxs, tr);
+
+		if (!tr.DidHit ())
 		{
-			// Try to push the player onto the ledge.
-			Vector vecOrigin = mv->GetAbsOrigin();
-			Vector vecTarget = vecOrigin + Vector(m_vecForward.x, m_vecForward.y, 0).Normalized();
-
-			TraceBBox(vecOrigin, vecTarget, mins, maxs, tr);
-
-			if (!tr.DidHit ())
-			{
-				mv->SetAbsOrigin (tr.endpos);
-				m_pSDKPlayer->m_Shared.ResetManteling();
-				m_pSDKPlayer->Instructor_LessonLearned("mantel");
-			}
-			else
-				SetGroundEntity(&tr);
+			mv->SetAbsOrigin (tr.endpos);
+			m_pSDKPlayer->m_Shared.ResetManteling();
+			m_pSDKPlayer->Instructor_LessonLearned("mantel");
 		}
-
-
+		else
+			SetGroundEntity(&tr);
 
 		return;
 	}

--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -2869,8 +2869,6 @@ void CSDKGameMovement::FullWalkMove ()
 		}
 
 		mv->SetAbsOrigin (tr.endpos);
-		if (!m_pSDKPlayer->m_Shared.IsManteling())
-			return;
 
 		// Try to push the player onto the ledge.
 		Vector vecOrigin = mv->GetAbsOrigin();

--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -2863,29 +2863,31 @@ void CSDKGameMovement::FullWalkMove ()
 		pr2[2] += gpGlobals->frametime*a;
 
 		TraceBBox (pr1, pr2, mins, maxs, tr);
-		if (tr.fraction == 1 && !tr.startsolid && !tr.allsolid)
-		{
-			mv->SetAbsOrigin (tr.endpos);
-			if (m_pSDKPlayer->m_Shared.IsManteling())
-			{
-				// Try to push the player onto the ledge.
-				Vector vecOrigin = mv->GetAbsOrigin();
-				Vector vecTarget = vecOrigin + Vector(m_vecForward.x, m_vecForward.y, 0).Normalized();
-
-				TraceBBox(vecOrigin, vecTarget, mins, maxs, tr);
-
-				if (!tr.DidHit ())
-				{
-					mv->SetAbsOrigin (tr.endpos);
-					m_pSDKPlayer->m_Shared.ResetManteling();
-					m_pSDKPlayer->Instructor_LessonLearned("mantel");
-				}
-				else
-					SetGroundEntity(&tr);
-			}
-		}
-		else
+		if (tr.fraction != 1 || tr.startsolid || tr.allsolid) {
 			m_pSDKPlayer->m_Shared.ResetManteling();
+			return;
+		}
+
+		mv->SetAbsOrigin (tr.endpos);
+		if (m_pSDKPlayer->m_Shared.IsManteling())
+		{
+			// Try to push the player onto the ledge.
+			Vector vecOrigin = mv->GetAbsOrigin();
+			Vector vecTarget = vecOrigin + Vector(m_vecForward.x, m_vecForward.y, 0).Normalized();
+
+			TraceBBox(vecOrigin, vecTarget, mins, maxs, tr);
+
+			if (!tr.DidHit ())
+			{
+				mv->SetAbsOrigin (tr.endpos);
+				m_pSDKPlayer->m_Shared.ResetManteling();
+				m_pSDKPlayer->Instructor_LessonLearned("mantel");
+			}
+			else
+				SetGroundEntity(&tr);
+		}
+
+
 
 		return;
 	}

--- a/mp/src/game/shared/sdk/sdk_gamemovement.cpp
+++ b/mp/src/game/shared/sdk/sdk_gamemovement.cpp
@@ -2836,7 +2836,21 @@ void CSDKGameMovement::FullWalkMove ()
 		}
 	}
 #endif
-	if (CheckMantel())
+
+	// Check if we're manteling
+	bool canMantel = CheckMantel();
+
+	// Calculate planarized wall normal
+	Vector vecWallNormal = m_pSDKPlayer->m_Shared.GetMantelWallNormal();
+	vecWallNormal.z = 0;
+	VectorNormalize(vecWallNormal);
+
+	if (canMantel && vecWallNormal.Dot(Vector(m_vecForward.x, m_vecForward.y, 0).Normalized()) > -0.05) {
+		m_pSDKPlayer->m_Shared.ResetManteling();
+		canMantel = false;
+	}
+
+	if (canMantel)
 	{
 		/*Move up the height of the bbox over the time of the animation
 		TODO: How get animation duration? Make this use the crouch bbox.*/
@@ -2872,7 +2886,7 @@ void CSDKGameMovement::FullWalkMove ()
 
 		// Try to push the player onto the ledge.
 		Vector vecOrigin = mv->GetAbsOrigin();
-		Vector vecTarget = vecOrigin + Vector(m_vecForward.x, m_vecForward.y, 0).Normalized();
+		Vector vecTarget = vecOrigin - vecWallNormal;
 
 		TraceBBox(vecOrigin, vecTarget, mins, maxs, tr);
 


### PR DESCRIPTION
Compared to the other climb bug, there are a ton more spots for this to exploit and it's also way easier to exploit.
I'm not going to try and count them :)

This introduces a tiny variance in the allowable angle between you and the wall.
That variance might have been wall-dependent before, now it's fixed to a dot product of 0.05, which is about 87.13° to the normal or 3° to the plane.
Shouldn't be noticable, since the most extreme place I tried had an allowable angle of about 88° to the normal under the old behaviour.

Thanks to Johnny shoe oswald man birb for reporting this.