### PR TITLE
Reset all kinds of stunts on spawn

### DIFF
--- a/mp/src/game/server/sdk/sdk_player.cpp
+++ b/mp/src/game/server/sdk/sdk_player.cpp
@@ -1164,6 +1164,10 @@ void CSDKPlayer::Spawn()
 	m_flNextSuicideTime = 0;
 	m_iRaceWaypoint = 0;
 
+	m_Shared.EndDive();
+	m_Shared.EndRoll();
+	m_Shared.EndSlide(true);
+
 	if (m_bGotWorthIt)
 	{
 		m_flTotalStyle += da_stylemeteractivationcost.GetFloat() - m_flStylePoints;

--- a/mp/src/game/shared/sdk/sdk_player_shared.cpp
+++ b/mp/src/game/shared/sdk/sdk_player_shared.cpp
@@ -819,10 +819,10 @@ void CSDKPlayerShared::StartSliding(bool bDiveSliding)
 	m_flLastUnSlideTime = 0;
 }
 
-void CSDKPlayerShared::EndSlide()
+void CSDKPlayerShared::EndSlide(bool abort)
 {
 	// If it was long enough to notice what it was, then train the slide.
-	if (m_pOuter->GetCurrentTime() - m_flSlideStartTime > 1)
+	if (!abort && m_pOuter->GetCurrentTime() - m_flSlideStartTime > 1)
 	{
 		if (m_bDiveSliding)
 			m_pOuter->Instructor_LessonLearned("slideafterdive");

--- a/mp/src/game/shared/sdk/sdk_player_shared.h
+++ b/mp/src/game/shared/sdk/sdk_player_shared.h
@@ -77,7 +77,7 @@ public:
 	void	PlayStartSlideSound();
 	void	PlayEndSlideSound();
 	void	StartSliding(bool bDiveSliding = false);
-	void	EndSlide();
+	void	EndSlide(bool abort = false);
 	void	StandUpFromSlide(bool bJumpUp = false);
 	float	GetSlideStartTime() const { return m_flSlideStartTime; };
 	float	GetSlideAutoEndTime() const { return m_flSlideAutoEndTime; };


### PR DESCRIPTION
I hope this will fix the "prone on spawn" bug that sometimes occurs.
The new "abort" flag in CSDKPlayerShared::EndSlide blocks the tutor popups, along with a crash in listen-server mode.