### PR TITLE
added weapon falloff and basic values - needs balancing

### DIFF
--- a/mp/game/dab/scripts/weapon_akimbo_beretta.txt
+++ b/mp/game/dab/scripts/weapon_akimbo_beretta.txt
@@ -8,6 +8,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"akimbo_m1911_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"512" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.005" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"12" // clamps the falloff
+
 	"BuiltRightHanded"		"0"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_akimbo_m1911.txt
+++ b/mp/game/dab/scripts/weapon_akimbo_m1911.txt
@@ -7,6 +7,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"akimbo_m1911_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"512" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.025" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"12" // clamps the falloff
+
 	"BuiltRightHanded"		"0"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_beretta.txt
+++ b/mp/game/dab/scripts/weapon_beretta.txt
@@ -7,6 +7,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"beretta_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"512" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.005" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"16" // clamps the falloff
+
 	"BuiltRightHanded"		"0"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_fal.txt
+++ b/mp/game/dab/scripts/weapon_fal.txt
@@ -8,6 +8,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"fal_aim"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"1024" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.001" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"18" // clamps the falloff
+
 	"BuiltRightHanded"		"1"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_m16.txt
+++ b/mp/game/dab/scripts/weapon_m16.txt
@@ -8,6 +8,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"m16_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"768" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.005" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"16" // clamps the falloff
+
 	"BuiltRightHanded"		"1"
 	
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_m1911.txt
+++ b/mp/game/dab/scripts/weapon_m1911.txt
@@ -9,6 +9,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"m1911_ready"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"512" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.025" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"22" // clamps the falloff
+
 	"BuiltRightHanded"		"1"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_mac10.txt
+++ b/mp/game/dab/scripts/weapon_mac10.txt
@@ -7,6 +7,13 @@ WeaponData
 	"ReloadTimeMultiplier"	"0.7"
 	"BrawlTimeMultiplier"	"1"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"512" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.005" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"8" // clamps the falloff
+
 	"BuiltRightHanded"		"0"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_mossberg.txt
+++ b/mp/game/dab/scripts/weapon_mossberg.txt
@@ -8,6 +8,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1.25"
 	"buy_menu_sequence"		"mossberg_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"128" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.008" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"6" // clamps the falloff
+
 	"BuiltRightHanded"		"1"
 	
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_mp5k.txt
+++ b/mp/game/dab/scripts/weapon_mp5k.txt
@@ -8,6 +8,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"mp5k_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"1024" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.0025" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"12" // clamps the falloff
+
 	"BuiltRightHanded"		"1"
 
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/game/dab/scripts/weapon_sawnoff.txt
+++ b/mp/game/dab/scripts/weapon_sawnoff.txt
@@ -8,6 +8,13 @@ WeaponData
 	"BrawlTimeMultiplier"	"1"
 	"buy_menu_sequence"		"m1911_run_idle"
 
+	// falloff variables
+	// our falloff calculation looks something like:
+	// distance less effective_range, multiplied by falloff_rate, removed from base damage, clamped to min_damage
+	"EffectiveRange"		"512" // the distance in units (inches) before any falloff is applied
+	"FalloffRate"			"0.05" // multiplied by the distance of the shot then removed from base damage
+	"MinDamage"				"4" // clamps the falloff
+
 	"BuiltRightHanded"		"1"
 	
 	// Weapon data is loaded by both the Game and Client DLLs.

--- a/mp/src/game/shared/sdk/sdk_weapon_parse.cpp
+++ b/mp/src/game/shared/sdk/sdk_weapon_parse.cpp
@@ -34,6 +34,11 @@ void CSDKWeaponInfo::Parse( KeyValues *pKeyValuesData, const char *szWeaponName 
 	m_flReloadTimeMultiplier = pKeyValuesData->GetFloat( "ReloadTimeMultiplier", 1 );
 	m_flDrawTimeMultiplier = pKeyValuesData->GetFloat( "DrawTimeMultiplier", 1 );
 
+	// falloff damage
+	m_flEffectiveRange	= pKeyValuesData->GetFloat( "EffectiveRange", 0 );
+	m_flFalloffRate		= pKeyValuesData->GetFloat( "FalloffRate", 0 );
+	m_flMinDamage		= pKeyValuesData->GetInt( "MinDamage", 0 );	
+
 	m_iDefaultAmmoClips = pKeyValuesData->GetInt( "NumClips", 2 );
 
 	const char *pAnimEx = pKeyValuesData->GetString( "PlayerAnimationExtension", "mp5" );

--- a/mp/src/game/shared/sdk/sdk_weapon_parse.h
+++ b/mp/src/game/shared/sdk/sdk_weapon_parse.h
@@ -37,6 +37,11 @@ public:
 	float	m_flReloadTimeMultiplier;
 	float	m_flDrawTimeMultiplier;
 
+	// weapon damage falloff
+	float m_flEffectiveRange;
+	float m_flFalloffRate;
+	float m_flMinDamage;
+
 	float m_flWeaponFOV;		//Tony; added weapon fov, SDK uses models from a couple different games, so FOV is different.
 
 	float	m_flViewPunchMultiplier;


### PR DESCRIPTION
This PR adds a per-weapon damage falloff calculation. It's fairly simple - each weapon has three new values in the weapon script: `EffectiveRange`, `FalloffRate` and `MinDamage`.

If an attacker is within their weapons effective range, no falloff is applied. If they are over the effective range we calculate the distance less the effective range and multiply that by the falloff rate. That value is then subtracted from the weapons base `Damage` in order to get our calculated damage. We then clamp the final value by the min damage, so we aren't falling off to negligible values.

This is going to really affect the balance of all weapons so we will need to spend some time tweaking values. I have just thrown some random values in the weapon scripts for now, nothing is set in stone.