### PR TITLE
Fix VGUI resource string overflows

### DIFF
--- a/mp/src/game/client/sdk/vgui/da_buymenu.cpp
+++ b/mp/src/game/client/sdk/vgui/da_buymenu.cpp
@@ -67,9 +67,9 @@ void CWeaponButton::ApplySettings( KeyValues *resourceData )
 {
 	BaseClass::ApplySettings( resourceData );
 
-	strcpy(m_szInfoString, resourceData->GetString("info_string"));
-	strcpy(m_szInfoModel, resourceData->GetString("info_model"));
-	strcpy(m_szWeaponID, resourceData->GetString("weaponid"));
+	Q_strncpy(m_szInfoString, resourceData->GetString("info_string"), sizeof(m_szInfoString));
+	Q_strncpy(m_szInfoModel, resourceData->GetString("info_model"), sizeof(m_szInfoModel));
+	Q_strncpy(m_szWeaponID, resourceData->GetString("weaponid"), sizeof(m_szWeaponID));
 }
 
 void CWeaponButton::ApplySchemeSettings( vgui::IScheme *pScheme )

--- a/mp/src/game/client/sdk/vgui/da_charactermenu.cpp
+++ b/mp/src/game/client/sdk/vgui/da_charactermenu.cpp
@@ -61,13 +61,13 @@ void CCharacterButton::ApplySettings( KeyValues *resourceData )
 {
 	BaseClass::ApplySettings( resourceData );
 
-	strcpy(m_szCharacter, resourceData->GetString("character"));
+	Q_strncpy(m_szCharacter, resourceData->GetString("character"), sizeof(m_szCharacter));
 
 	const char* pszSequence = resourceData->GetString("sequence", "");
-	strcpy(m_szSequence, pszSequence);
+	Q_strncpy(m_szSequence, pszSequence, sizeof(m_szSequence));
 
 	const char* pszWeaponModel = resourceData->GetString("weaponmodel", "");
-	strcpy(m_szWeaponModel, pszWeaponModel);
+	Q_strncpy(m_szWeaponModel, pszWeaponModel, sizeof(m_szWeaponModel));
 
 	m_flBodyYaw = resourceData->GetFloat("body_yaw");
 	m_flBodyPitch = resourceData->GetFloat("body_pitch");

--- a/mp/src/game/client/sdk/vgui/da_skillmenu.cpp
+++ b/mp/src/game/client/sdk/vgui/da_skillmenu.cpp
@@ -62,7 +62,7 @@ void CSkillButton::ApplySettings( KeyValues *resourceData )
 {
 	BaseClass::ApplySettings( resourceData );
 
-	strcpy(m_szSkillName, resourceData->GetString("skill"));
+	Q_strncpy(m_szSkillName, resourceData->GetString("skill"), sizeof(m_szSkillName));
 }
 
 void CSkillButton::OnCursorEntered()

--- a/mp/src/game/client/sdk/vgui/folder_gui.cpp
+++ b/mp/src/game/client/sdk/vgui/folder_gui.cpp
@@ -838,17 +838,17 @@ void CFolderMenu::ReloadControlSettings(bool bUpdate, bool bReloadPage)
 void CFolderMenu::SetCharacterPreview(const char* pszCharacter, const char* pszSequence, const char* pszWeaponModel, float flYaw, float flPitch)
 {
 	if (pszCharacter)
-		strcpy(m_szPreviewCharacter, pszCharacter);
+		Q_strncpy(m_szPreviewCharacter, pszCharacter, sizeof(m_szPreviewCharacter));
 	else
 		m_szPreviewCharacter[0] = '\0';
 
 	if (pszSequence)
-		strcpy(m_szPreviewSequence, pszSequence);
+		Q_strncpy(m_szPreviewSequence, pszSequence, sizeof(m_szPreviewSequence));
 	else
 		m_szPreviewSequence[0] = '\0';
 
 	if (pszWeaponModel)
-		strcpy(m_szPreviewWeaponModel, pszWeaponModel);
+		Q_strncpy(m_szPreviewWeaponModel, pszWeaponModel, sizeof(m_szPreviewWeaponModel));
 	else
 		m_szPreviewWeaponModel[0] = '\0';
 


### PR DESCRIPTION
Fixes unsafe VGUI resource string copies by replacing strcpy() with bounded Q_strncpy().